### PR TITLE
Fix possible NullPointerException and ArrayIndexOutOfBoundsException.

### DIFF
--- a/android/library/src/main/java/org/jdeferred/android/DeferredAsyncTask.java
+++ b/android/library/src/main/java/org/jdeferred/android/DeferredAsyncTask.java
@@ -76,9 +76,8 @@ public abstract class DeferredAsyncTask<Params, Progress, Result> extends AsyncT
 			deferred.notify(null);
 		} else if (values.length > 1) {
 			log.warn("There were multiple progress values.  Only the first one was used!");
+			deferred.notify(values[0]);
 		}
-		
-		deferred.notify(values[0]);
 	};
 	
 	protected final Result doInBackground(Params ... params) {


### PR DESCRIPTION
Wouldn't this cause a `NullPointerException` when `values` is null or an `ArrayIndexOutOfBoundsException` when the length of `values` is zero?

Suggestion: move it in the `else if` clause.
