### PR TITLE
Add interface to execute task on specify task executor

### DIFF
--- a/android/library/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
@@ -111,15 +111,15 @@ public class AndroidDeferredManager extends DefaultDeferredManager {
 	}
 	
 	@SuppressWarnings("rawtypes")
-    public Promise<MultipleResults, OneReject, MasterProgress> when(AndroidExecutionScope scope,
-            DeferredAsyncTask<Void, ?, ?> ... tasks) {
-        assertNotEmpty(tasks);
-        Promise[] promises = new Promise[tasks.length];
-        for (int i = 0; i < tasks.length; i++) {
-            promises[i] = when(tasks[i]);
-        }
-        return when(scope, promises);
-    }
+	public Promise<MultipleResults, OneReject, MasterProgress> when(AndroidExecutionScope scope,
+			DeferredAsyncTask<Void, ?, ?> ... tasks) {
+		assertNotEmpty(tasks);
+		Promise[] promises = new Promise[tasks.length];
+		for (int i = 0; i < tasks.length; i++) {
+			promises[i] = when(tasks[i]);
+		}
+		return when(scope, promises);
+	}
 
 	/**
 	 * Wrap with {@link AndroidDeferredObject} so that callbacks can be executed in UI thread.
@@ -156,12 +156,12 @@ public class AndroidDeferredManager extends DefaultDeferredManager {
 		return new AndroidDeferredObject<D, F, P>(promise).promise();
 	}
 
-    public <D, F, P> Promise<D, F, P> when(Promise<D, F, P> promise, AndroidExecutionScope scope) {
-        if (promise instanceof AndroidDeferredObject) {
-            return promise;
-        }
-        return new AndroidDeferredObject<D, F, P>(promise, scope).promise();
-    }
+	public <D, F, P> Promise<D, F, P> when(AndroidExecutionScope scope, Promise<D, F, P> promise) {
+		if (promise instanceof AndroidDeferredObject) {
+			return promise;
+		}
+		return new AndroidDeferredObject<D, F, P>(promise, scope).promise();
+	}
 
 	/**
 	 * Wraps {@link MasterDeferredObject} with {@link AndroidDeferredObject} so that callbacks can
@@ -175,8 +175,8 @@ public class AndroidDeferredManager extends DefaultDeferredManager {
 	}
 
 	@SuppressWarnings({ "rawtypes" })
-    public Promise<MultipleResults, OneReject, MasterProgress> when(AndroidExecutionScope scope, Promise... promises) {
-        return new AndroidDeferredObject<MultipleResults, OneReject, MasterProgress>
-            (super.when(promises), scope).promise();
-    }
+	public Promise<MultipleResults, OneReject, MasterProgress> when(AndroidExecutionScope scope, Promise... promises) {
+		return new AndroidDeferredObject<MultipleResults, OneReject, MasterProgress>
+			(super.when(promises), scope).promise();
+	}
 }


### PR DESCRIPTION
We extended interfaces to have ability to execute tasks in specified executor.
It's very useful when user want to have finer control of executed tasks.
