### PR TITLE
Ensure Android callback handler always on main thread

### DIFF
--- a/android/library/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
@@ -68,6 +68,10 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 	}
 
 	private static class InternalHandler extends Handler {
+		public InternalHandler() {
+			super(Looper.getMainLooper());
+		}
+
 		@SuppressWarnings({ "unchecked", "rawtypes" })
 		@Override
 		public void handleMessage(Message msg) {


### PR DESCRIPTION
Since the contract of AndroidDeferredManager is that the callbacks
always occur on the main thread, even if the AndroidDeferredObject is
instantiated on a background thread.
