### PR TITLE
OneReject should extend Throwable

### DIFF
--- a/core/src/main/java/org/jdeferred/multiple/OneReject.java
+++ b/core/src/main/java/org/jdeferred/multiple/OneReject.java
@@ -23,7 +23,7 @@ import org.jdeferred.Promise;
  *
  */
 @SuppressWarnings("rawtypes")
-public class OneReject {
+public class OneReject extends Throwable {
 	private final int index;
 	private final Promise promise;
 	private final Object reject;


### PR DESCRIPTION
Hello,

first of all thanks for your work, this library is very helpful and made my code much more readable.
I think I might have found a small glitch.
I wrote some code with this structure:

````java
DeferredManager dm = new DefaultDeferredManager();
Promise p1, p2;
// Initialize promises p1, p2
dm.when(p1, p2)
.then(new DonePipe<MultipleResults, String, Throwable, Void>() {
            @Override
            public Promise<String, Throwable, Void> pipeDone(MultipleResults results) {
                Promise p3 = createAndGetPromise4();
                return p3;
            }
        })
.then(new DonePipe<String, Integer, Throwable, Void>() { 
        @Override
            public Promise<Integer, Throwable, Void> pipeDone(String result) {
                Promise p4 = createAndGetPromise4();
                return p4;
            }
        })
.done(new DoneCallback<Integer>() {
            @Override
            public void onDone(Integer result) {
                //do something
            }
        })
.fail(new FailCallback<Throwable>() {
            @Override
            public void onFail(Throwable e) {
                // p2 fails and I get org.jdeferred.multiple.OneReject which cannot be cast to Throwable
            }
        })
````

When p2 fails I get this exception
````
java.lang.ClassCastException: org.jdeferred.multiple.OneReject cannot be cast to java.lang.Throwable
````

Perhaps class OneReject should extend Throwable?

Thanks for your amazing work :)
