### PR TITLE
Keeping doneCallbacks clean, massive memory leaks fix

### DIFF
--- a/core/src/main/java/org/jdeferred/impl/AbstractPromise.java
+++ b/core/src/main/java/org/jdeferred/impl/AbstractPromise.java
@@ -59,8 +59,11 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	@Override
 	public Promise<D, F, P> done(DoneCallback<D> callback) {
 		synchronized (this) {
-			doneCallbacks.add(callback);
-			if (isResolved()) triggerDone(callback, resolveResult);
+			if (isResolved()){
+				triggerDone(callback, resolveResult);
+			}else{
+				doneCallbacks.add(callback);
+			}
 		}
 		return this;
 	}
@@ -68,8 +71,11 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	@Override
 	public Promise<D, F, P> fail(FailCallback<F> callback) {
 		synchronized (this) {
-			failCallbacks.add(callback);
-			if (isRejected()) triggerFail(callback, rejectResult);
+			if(isRejected()){
+				triggerFail(callback, rejectResult);
+			}else{
+				failCallbacks.add(callback);
+			}
 		}
 		return this;
 	}
@@ -77,8 +83,11 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	@Override
 	public Promise<D, F, P> always(AlwaysCallback<D, F> callback) {
 		synchronized (this) {
-			alwaysCallbacks.add(callback);
-			if (!isPending()) triggerAlways(callback, state, resolveResult, rejectResult);
+			if(isPending()){
+				alwaysCallbacks.add(callback);
+			}else{
+				triggerAlways(callback, state, resolveResult, rejectResult);
+			}
 		}
 		return this;
 	}
@@ -91,6 +100,7 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 				log.error("an uncaught exception occured in a DoneCallback", e);
 			}
 		}
+		doneCallbacks.clear();
 	}
 	
 	protected void triggerDone(DoneCallback<D> callback, D resolved) {
@@ -105,6 +115,7 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 				log.error("an uncaught exception occured in a FailCallback", e);
 			}
 		}
+		failCallbacks.clear();
 	}
 	
 	protected void triggerFail(FailCallback<F> callback, F rejected) {
@@ -133,6 +144,7 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 				log.error("an uncaught exception occured in a AlwaysCallback", e);
 			}
 		}
+		alwaysCallbacks.clear();
 		
 		synchronized (this) {
 			this.notifyAll();


### PR DESCRIPTION
Originally doneCallbacks never have been cleaned, this way if DeferredObject is application level and different views, android activities passing themselves as callback - reference kept forever causing massive memory leaks.

Moreover, objects that register callbacks after .resolve/reject was called still were written into callbacks lists
