### PR TITLE
Adds the possibility to cancel all callbacks of a promise

### DIFF
--- a/core/src/main/java/org/jdeferred/Promise.java
+++ b/core/src/main/java/org/jdeferred/Promise.java
@@ -341,6 +341,6 @@ public interface Promise<D, F, P> {
 	/**
 	 * Clear all callbacks of this promise if the state is Pending.
 	 */
-	public void cancel();
+	public void clearCallbacks();
 
 }

--- a/core/src/main/java/org/jdeferred/Promise.java
+++ b/core/src/main/java/org/jdeferred/Promise.java
@@ -337,5 +337,10 @@ public interface Promise<D, F, P> {
 	 * @throws InterruptedException
 	 */
 	public void waitSafely(long timeout) throws InterruptedException;
-	
+
+	/**
+	 * Clear all callbacks of this promise if the state is Pending.
+	 */
+	public void cancel();
+
 }

--- a/core/src/main/java/org/jdeferred/impl/AbstractPromise.java
+++ b/core/src/main/java/org/jdeferred/impl/AbstractPromise.java
@@ -267,7 +267,7 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	}
 
 	@Override
-	public void cancel() {
+	public void clearCallbacks() {
 		synchronized (this) {
 			if(state == State.PENDING) {
 				doneCallbacks.clear();

--- a/core/src/main/java/org/jdeferred/impl/AbstractPromise.java
+++ b/core/src/main/java/org/jdeferred/impl/AbstractPromise.java
@@ -265,4 +265,17 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 			}
 		}
 	}
+
+	@Override
+	public void cancel() {
+		synchronized (this) {
+			if(state == State.PENDING) {
+				doneCallbacks.clear();
+				failCallbacks.clear();
+				progressCallbacks.clear();
+				alwaysCallbacks.clear();
+			}
+		}
+	}
+
 }

--- a/core/src/main/java/org/jdeferred/impl/DeferredPromise.java
+++ b/core/src/main/java/org/jdeferred/impl/DeferredPromise.java
@@ -111,6 +111,11 @@ public class DeferredPromise<D, F, P> implements Promise<D, F, P> {
 	}
 
 	@Override
+	public void cancel() {
+		promise.cancel();
+	}
+
+	@Override
 	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DonePipe<D, D_OUT, F_OUT, P_OUT> doneFilter) {
 		return promise.then(doneFilter);

--- a/core/src/main/java/org/jdeferred/impl/DeferredPromise.java
+++ b/core/src/main/java/org/jdeferred/impl/DeferredPromise.java
@@ -111,8 +111,8 @@ public class DeferredPromise<D, F, P> implements Promise<D, F, P> {
 	}
 
 	@Override
-	public void cancel() {
-		promise.cancel();
+	public void clearCallbacks() {
+		promise.clearCallbacks();
 	}
 
 	@Override


### PR DESCRIPTION
This method try to help apps developers that wan't to prevent leaks of Activity/Fragment when a user is leaving them and a promise is pending to be completed. Removing all callbacks let the Activity/Fragment to be garbage collected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jdeferred/jdeferred/50)
<!-- Reviewable:end -->
