### PR TITLE
fix : warning not appropiate when parameter's length is 1

### DIFF
--- a/android/library/src/main/java/org/jdeferred/android/DeferredAsyncTask.java
+++ b/android/library/src/main/java/org/jdeferred/android/DeferredAsyncTask.java
@@ -74,7 +74,9 @@ public abstract class DeferredAsyncTask<Params, Progress, Result> extends AsyncT
 	protected final void onProgressUpdate(Progress ... values) {
 		if (values == null || values.length == 0) {
 			deferred.notify(null);
-		} else if (values.length > 0) {
+		} else if (values.length == 1) {
+			deferred.notify(values[0]);
+		} else {
 			log.warn("There were multiple progress values.  Only the first one was used!");
 			deferred.notify(values[0]);
 		}


### PR DESCRIPTION
The "There were multiple progress values. [...]" warning is misleading when only one value is getting passed.