### PR TITLE
Add empty constructor to AndroidDeferredObject for convenience

### DIFF
--- a/android/library/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
@@ -45,6 +45,10 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 	
 	private final AndroidExecutionScope defaultAndroidExecutionScope;
 
+	public AndroidDeferredObject() {
+		this(new DeferredObject<D, F, P>());
+	}
+
 	public AndroidDeferredObject(Promise<D, F, P> promise) {
 		this(promise, AndroidExecutionScope.UI);
 	}


### PR DESCRIPTION
before: new AndroidDeferredObject<>(new DeferredObject\<String, String, String\>());
after: new AndroidDeferredObject<>();