### PR TITLE
Piped-promises for Android

### DIFF
--- a/android/library-aar/AndroidManifest.xml
+++ b/android/library-aar/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2013 Ray Tsang
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+    http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.jdeferred.android.annotation"
+    android:versionCode="1"
+    android:versionName="1.2.0" >
+    
+    <uses-sdk
+        android:minSdkVersion="8"
+        android:targetSdkVersion="19" />
+</manifest>

--- a/android/library/src/main/java/org/jdeferred/android/AndroidDeferred.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidDeferred.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013 Ray Tsang
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdeferred.android;
+
+import org.jdeferred.Deferred;
+
+public interface AndroidDeferred<D, F, P> extends Deferred<D, F, P>, AndroidPromise<D, F, P> {
+	AndroidDeferred<D, F, P> resolve(final D resolve);
+	AndroidDeferred<D, F, P> reject(final F reject);
+	AndroidDeferred<D, F, P> notify(final P progress);
+	AndroidPromise<D, F, P> promise();
+}

--- a/android/library/src/main/java/org/jdeferred/android/AndroidDoneFilter.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidDoneFilter.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright 2013 Ray Tsang
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.jdeferred.android;
+
+import org.jdeferred.DoneFilter;
+
+public interface AndroidDoneFilter<D, D_OUT> extends DoneFilter<D, D_OUT>, AndroidExecutionScopeable {
+
+}

--- a/android/library/src/main/java/org/jdeferred/android/AndroidDonePipe.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidDonePipe.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright 2013 Ray Tsang
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.jdeferred.android;
+
+public interface AndroidDonePipe<D, D_OUT, F_OUT, P_OUT> extends AndroidExecutionScopeable {
+    AndroidPromise<D_OUT, F_OUT, P_OUT> pipeDone(final D result);
+}

--- a/android/library/src/main/java/org/jdeferred/android/AndroidFailFilter.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidFailFilter.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright 2013 Ray Tsang
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.jdeferred.android;
+
+import org.jdeferred.FailFilter;
+
+public interface AndroidFailFilter<F, F_OUT> extends FailFilter<F, F_OUT>, AndroidExecutionScopeable {
+
+}

--- a/android/library/src/main/java/org/jdeferred/android/AndroidFailPipe.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidFailPipe.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013 Ray Tsang
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdeferred.android;
+
+import org.jdeferred.DonePipe;
+import org.jdeferred.Promise;
+
+/**
+ * @see Promise#then(DonePipe, FailPipe)
+ * @author Ray Tsang
+ *
+ * @param <P> Type of the input
+ * @param <P_OUT> Type of the output from this filter
+ */
+public interface AndroidFailPipe<F, D_OUT, F_OUT, P_OUT> extends AndroidExecutionScopeable {
+	public Promise<D_OUT, F_OUT, P_OUT> pipeFail(final F result);
+}

--- a/android/library/src/main/java/org/jdeferred/android/AndroidMasterDeferredObject.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidMasterDeferredObject.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2013 Ray Tsang
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdeferred.android;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jdeferred.AlwaysCallback;
+import org.jdeferred.DoneCallback;
+import org.jdeferred.FailCallback;
+import org.jdeferred.ProgressCallback;
+import org.jdeferred.Promise;
+import org.jdeferred.android.AndroidDeferredObject;
+import org.jdeferred.android.AndroidPromise;
+import org.jdeferred.impl.DeferredObject;
+import org.jdeferred.multiple.*;
+
+/**
+ * This will return a special Promise called {@link MasterDeferredObject}. In short,
+ * <ul>
+ * <li>{@link Promise#done(DoneCallback)} will be triggered if all promises resolves
+ * (i.e., all finished successfully) with {@link MultipleResults}.</li>
+ * <li>{@link Promise#fail(FailCallback)} will be
+ * triggered if any promises rejects (i.e., if any one failed) with {@link OneReject}.</li>
+ * <li>{@link Promise#progress(ProgressCallback)} will be triggered whenever one
+ * promise resolves or rejects ({#link {@link MasterProgress}), 
+ * or whenever a promise was notified progress ({@link OneProgress}).</li>
+ * <li>{@link Promise#always(AlwaysCallback)} will be triggered whenever
+ * {@link Promise#done(DoneCallback)} or {@link Promise#fail(FailCallback)}
+ * would be triggered</li>
+ * </ul>
+ *
+ * @author Ray Tsang
+ *
+ */
+@SuppressWarnings("rawtypes")
+public class AndroidMasterDeferredObject extends
+		AndroidDeferredObject<MultipleResults, OneReject, MasterProgress>
+		implements AndroidPromise<MultipleResults, OneReject, MasterProgress> {
+	private final int numberOfPromises;
+	private final AtomicInteger doneCount = new AtomicInteger();
+	private final AtomicInteger failCount = new AtomicInteger();
+	private final AndroidMultipleResults results;
+
+	@SuppressWarnings("unchecked")
+	public AndroidMasterDeferredObject(Promise... promises) {
+		if (promises == null || promises.length == 0)
+			throw new IllegalArgumentException("Promises is null or empty");
+		this.numberOfPromises = promises.length;
+		results = new AndroidMultipleResults(numberOfPromises);
+
+		int count = 0;
+		for (final Promise promise : promises) {
+			final int index = count++;
+			promise.fail(new AndroidFailCallback<Object>() {
+				@Override
+				public AndroidExecutionScope getExecutionScope() {
+					return AndroidExecutionScope.BACKGROUND;
+				}
+
+				public void onFail(Object result) {
+					synchronized (AndroidMasterDeferredObject.this) {
+						if (!AndroidMasterDeferredObject.this.isPending())
+							return;
+
+						final int fail = failCount.incrementAndGet();
+						AndroidMasterDeferredObject.this.notify(new MasterProgress(
+								doneCount.get(),
+								fail,
+								numberOfPromises));
+
+						AndroidMasterDeferredObject.this.reject(new OneReject(index, promise, result));
+					}
+				}
+			}).progress(new AndroidProgressCallback() {
+				@Override
+				public AndroidExecutionScope getExecutionScope() {
+					return AndroidExecutionScope.BACKGROUND;
+				}
+
+				public void onProgress(Object progress) {
+					synchronized (AndroidMasterDeferredObject.this) {
+						if (!AndroidMasterDeferredObject.this.isPending())
+							return;
+
+						AndroidMasterDeferredObject.this.notify(new OneProgress(
+								doneCount.get(),
+								failCount.get(),
+								numberOfPromises, index, promise, progress));
+					}
+				}
+			}).done(new AndroidDoneCallback() {
+				@Override
+				public AndroidExecutionScope getExecutionScope() {
+					return AndroidExecutionScope.BACKGROUND;
+				}
+
+				public void onDone(Object result) {
+					synchronized (AndroidMasterDeferredObject.this) {
+						if (!AndroidMasterDeferredObject.this.isPending())
+							return;
+
+						results.set(index, new OneResult(index, promise,
+								result));
+						int done = doneCount.incrementAndGet();
+
+						AndroidMasterDeferredObject.this.notify(new MasterProgress(
+								done,
+								failCount.get(),
+								numberOfPromises));
+
+						if (done == numberOfPromises) {
+							AndroidMasterDeferredObject.this.resolve(results);
+						}
+					}
+				}
+			});
+		}
+	}
+}

--- a/android/library/src/main/java/org/jdeferred/android/AndroidMultipleResults.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidMultipleResults.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 Ray Tsang
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdeferred.android;
+
+import org.jdeferred.multiple.MultipleResults;
+import org.jdeferred.multiple.OneResult;
+
+
+/**
+ * Contains a list of {@link OneResult}.
+ * @author Ray Tsang
+ *
+ */
+public class AndroidMultipleResults extends MultipleResults {
+	public AndroidMultipleResults(int size) {
+		super(size);
+	}
+
+	@Override
+	protected void set(int index, OneResult result) {
+		super.set(index, result);
+	}
+}

--- a/android/library/src/main/java/org/jdeferred/android/AndroidPipedPromise.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidPipedPromise.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013 Ray Tsang
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdeferred.android;
+
+import org.jdeferred.Promise;
+import org.jdeferred.impl.DeferredObject;
+
+public class AndroidPipedPromise<D, F, P, D_OUT, F_OUT, P_OUT> extends AndroidDeferredObject<D_OUT, F_OUT, P_OUT> implements AndroidPromise<D_OUT, F_OUT, P_OUT> {
+	public AndroidPipedPromise(final Promise<D, F, P> promise, final AndroidDonePipe<D, D_OUT, F_OUT, P_OUT> doneFilter, final AndroidFailPipe<F, D_OUT, F_OUT, P_OUT> failFilter, final AndroidProgressPipe<P, D_OUT, F_OUT, P_OUT> progressFilter) {
+		promise.done(new AndroidDoneCallback<D>() {
+			@Override
+			public AndroidExecutionScope getExecutionScope() {
+				return doneFilter!=null ? doneFilter.getExecutionScope() : AndroidExecutionScope.BACKGROUND;
+			}
+
+			@SuppressWarnings("unchecked")
+			@Override
+			public void onDone(D result) {
+				if (doneFilter != null) pipe(doneFilter.pipeDone(result));
+				else AndroidPipedPromise.this.resolve((D_OUT) result);
+
+			}
+		}).fail(new AndroidFailCallback<F>() {
+			@Override
+			public AndroidExecutionScope getExecutionScope() {
+				return doneFilter!=null ? doneFilter.getExecutionScope() : AndroidExecutionScope.BACKGROUND;
+			}
+
+			@SuppressWarnings("unchecked")
+			@Override
+			public void onFail(F result) {
+				if (failFilter != null)  pipe(failFilter.pipeFail(result));
+				else AndroidPipedPromise.this.reject((F_OUT) result);
+			}
+		}).progress(new AndroidProgressCallback<P>() {
+			@Override
+			public AndroidExecutionScope getExecutionScope() {
+				return doneFilter!=null ? doneFilter.getExecutionScope() : AndroidExecutionScope.BACKGROUND;
+			}
+
+			@SuppressWarnings("unchecked")
+			@Override
+			public void onProgress(P progress) {
+				if (progressFilter != null) pipe(progressFilter.pipeProgress(progress));
+				else AndroidPipedPromise.this.notify((P_OUT) progress);
+			}
+		});
+	}
+	
+	protected Promise<D_OUT, F_OUT, P_OUT> pipe(final Promise<D_OUT, F_OUT, P_OUT> promise) {
+		promise.done(new AndroidDoneCallback<D_OUT>() {
+			@Override
+			public AndroidExecutionScope getExecutionScope() {
+				return AndroidExecutionScope.BACKGROUND;
+			}
+
+			@Override
+			public void onDone(D_OUT result) {
+				AndroidPipedPromise.this.resolve(result);
+			}
+		}).fail(new AndroidFailCallback<F_OUT>() {
+			@Override
+			public AndroidExecutionScope getExecutionScope() {
+				return AndroidExecutionScope.BACKGROUND;
+			}
+
+			@Override
+			public void onFail(F_OUT result) {
+				AndroidPipedPromise.this.reject(result);
+			}
+		}).progress(new AndroidProgressCallback<P_OUT>() {
+			@Override
+			public AndroidExecutionScope getExecutionScope() {
+				return AndroidExecutionScope.BACKGROUND;
+			}
+
+			@Override
+			public void onProgress(P_OUT progress) {
+				AndroidPipedPromise.this.notify(progress);
+			}
+		});
+		
+		return promise;
+	}
+}

--- a/android/library/src/main/java/org/jdeferred/android/AndroidProgressFilter.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidProgressFilter.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright 2013 Ray Tsang
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.jdeferred.android;
+
+import org.jdeferred.ProgressFilter;
+
+public interface AndroidProgressFilter<P, P_OUT> extends ProgressFilter<P, P_OUT>, AndroidExecutionScopeable {
+
+}

--- a/android/library/src/main/java/org/jdeferred/android/AndroidProgressPipe.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidProgressPipe.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013 Ray Tsang
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdeferred.android;
+
+import org.jdeferred.FailFilter;
+import org.jdeferred.Promise;
+
+/**
+ * @see Promise#then(AndroidProgressPipe, FailFilter)
+ * @author Ray Tsang
+ *
+ * @param <P> Type of the input
+ * @param <P_OUT> Type of the output from this filter
+ */
+public interface AndroidProgressPipe<P, D_OUT, F_OUT, P_OUT> extends AndroidExecutionScopeable {
+	public Promise<D_OUT, F_OUT, P_OUT> pipeProgress(final P result);
+}

--- a/android/library/src/main/java/org/jdeferred/android/AndroidPromise.java
+++ b/android/library/src/main/java/org/jdeferred/android/AndroidPromise.java
@@ -1,0 +1,25 @@
+package org.jdeferred.android;
+
+import org.jdeferred.*;
+
+public interface AndroidPromise<D, F, P> extends Promise<D,F,P> {
+    <D_OUT, F_OUT, P_OUT> AndroidPromise<D_OUT, F_OUT, P_OUT> then(AndroidDonePipe<D, D_OUT, F_OUT, P_OUT> doneFilter);
+    <D_OUT, F_OUT, P_OUT> AndroidPromise<D_OUT, F_OUT, P_OUT> then(
+            AndroidDonePipe<D, D_OUT, F_OUT, P_OUT> doneFilter,
+            AndroidFailPipe<F, D_OUT, F_OUT, P_OUT> failFilter);
+    <D_OUT, F_OUT, P_OUT> AndroidPromise<D_OUT, F_OUT, P_OUT> then(
+            AndroidDonePipe<D, D_OUT, F_OUT, P_OUT> doneFilter,
+            AndroidFailPipe<F, D_OUT, F_OUT, P_OUT> failFilter,
+            AndroidProgressPipe<P, D_OUT, F_OUT, P_OUT> progressFilter);
+
+    AndroidPromise<D, F, P> then(AndroidDoneCallback<D> doneCallback);
+    AndroidPromise<D, F, P> then(AndroidDoneCallback<D> doneCallback,
+                                 AndroidFailCallback<F> failCallback);
+    AndroidPromise<D, F, P> then(AndroidDoneCallback<D> doneCallback,
+                                 AndroidFailCallback<F> failCallback, AndroidProgressCallback<P> progressCallback);
+
+    AndroidPromise<D, F, P> done(AndroidDoneCallback<D> callback);
+    AndroidPromise<D, F, P> fail(AndroidFailCallback<F> callback);
+    AndroidPromise<D, F, P> always(AndroidAlwaysCallback<D, F> callback);
+
+}

--- a/android/test/src/main/java/org/jdeferred/android/test/AndroidDeferredManagerTest.java
+++ b/android/test/src/main/java/org/jdeferred/android/test/AndroidDeferredManagerTest.java
@@ -3,15 +3,20 @@ package org.jdeferred.android.test;
 import junit.framework.Assert;
 
 import org.jdeferred.DoneCallback;
-import org.jdeferred.android.AndroidDeferredManager;
-import org.jdeferred.android.DeferredAsyncTask;
+import org.jdeferred.Promise;
+import org.jdeferred.android.*;
 
 import android.test.AndroidTestCase;
+import org.jdeferred.android.annotation.ExecutionScope;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
 
 public class AndroidDeferredManagerTest extends AndroidTestCase {
-	protected AndroidDeferredManager dm = new AndroidDeferredManager();
-
 	public void testDeferredAsyncTask() {
+		AndroidDeferredManager dm = new AndroidDeferredManager();
+
 		final ValueHolder<String> backgroundThreadGroupName = new ValueHolder<String>();
 		final ValueHolder<String> doneThreadGroupName = new ValueHolder<String>();
 
@@ -44,5 +49,79 @@ public class AndroidDeferredManagerTest extends AndroidTestCase {
 						backgroundThreadGroupName.get(),
 						doneThreadGroupName.get()), backgroundThreadGroupName
 						.equals(doneThreadGroupName));
+	}
+
+	public void testPipedPromise() {
+		AndroidDeferredManager dm = new AndroidDeferredManager();
+
+		final ExecutionScopeTester executionScopeTester = new ExecutionScopeTester();
+
+		final List<AndroidExecutionScope> scopes = new ArrayList<>();
+		final List<String> outputs = new ArrayList<>();
+
+		try {
+			dm.when(new Callable<String>() {
+				@Override
+				public String call() throws Exception {
+					return "string1";
+				}
+			}).then(new AndroidDonePipe<String, String, Throwable, Void>() {
+
+				@Override
+				public AndroidExecutionScope getExecutionScope() {
+					return AndroidExecutionScope.BACKGROUND;
+				}
+
+				@Override
+				public AndroidPromise<String, Throwable, Void> pipeDone(String result) {
+					scopes.add(executionScopeTester.determineExecutionScopeForObject(this));
+					outputs.add(result);
+					return new AndroidDeferredObject<String, Throwable, Void>().resolve("string2");
+				}
+			})
+			.then(new AndroidDonePipe<String, String, Throwable, Void>() {
+				@Override
+				public AndroidPromise<String, Throwable, Void> pipeDone(String result) {
+					scopes.add(executionScopeTester.determineExecutionScopeForObject(this));
+					outputs.add(result);
+					return new AndroidDeferredObject<String, Throwable, Void>().resolve("string3");
+				}
+
+				@Override
+				public AndroidExecutionScope getExecutionScope() {
+					return AndroidExecutionScope.UI;
+				}
+			})
+			.done(new AndroidDoneCallback<String>() {
+				@Override
+				public AndroidExecutionScope getExecutionScope() {
+					return AndroidExecutionScope.BACKGROUND;
+				}
+
+				@Override
+				public void onDone(String result) {
+					scopes.add(executionScopeTester.determineExecutionScopeForObject(this));
+
+					outputs.add(result);
+				}
+			})
+			.waitSafely();
+		} catch (InterruptedException e) {
+			// Do nothing
+		}
+
+		Assert.assertEquals("string1", outputs.get(0));
+		Assert.assertEquals("string2", outputs.get(1));
+		Assert.assertEquals("string3", outputs.get(2));
+
+		Assert.assertEquals(AndroidExecutionScope.BACKGROUND, scopes.get(0));
+		Assert.assertEquals(AndroidExecutionScope.UI, scopes.get(1));
+		Assert.assertEquals(AndroidExecutionScope.BACKGROUND, outputs.get(2));
+	}
+
+	private class ExecutionScopeTester extends AndroidDeferredObject {
+		public AndroidExecutionScope determineExecutionScopeForObject(Object object) {
+			return this.determineAndroidExecutionScope(object);
+		}
 	}
 }


### PR DESCRIPTION
I added piped promises for Android as best as I could without modifying the non-Android code-base. This restriction unfortunately prohibited me from writing type-safe code (i.e. enforce use of Android-only promises when AndroidDeferredManager is used), so instead I had to fallback to enforcing the use of Android-promises by throwing exceptions whenever a non-Android promise is used in an Android-context.

Also I could not get the test-suite running in IntelliJ IDEA, so I am not sure if the single test I added even works, you will have to try that for yourself. I _do_ use the code from this PR actively on a daily base though, which leads me to believe it works pretty well.