### PR TITLE
DeferredFutureTask always throws CancellationException when cancelled

### DIFF
--- a/core/src/main/java/org/jdeferred/DeferredFutureTask.java
+++ b/core/src/main/java/org/jdeferred/DeferredFutureTask.java
@@ -78,6 +78,7 @@ public class DeferredFutureTask<D, P> extends FutureTask<D> {
 		try {
 			if (isCancelled()) {
 				deferred.reject(new CancellationException());
+				return;
 			}
 			D result = get();
 			deferred.resolve(result);

--- a/core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
+++ b/core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
@@ -1,0 +1,46 @@
+package org.jdeferred.impl;
+
+import org.jdeferred.DeferredFutureTask;
+import org.jdeferred.DoneCallback;
+import org.jdeferred.Promise;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+
+public class CancelTaskTest extends AbstractDeferredTest {
+
+	@Test
+	public void testCancelTask() {
+		DeferredFutureTask<String, Void> deferredFutureTask =
+				new DeferredFutureTask<String, Void>(new Callable<String>() {
+					@Override
+					public String call() throws Exception {
+						try {
+							Thread.sleep(1000);
+						} catch (InterruptedException e) {
+						}
+
+						return "Hello";
+					}
+				});
+
+		Promise<String, Throwable, Void> promise = deferredManager.when(deferredFutureTask);
+
+		deferredFutureTask.cancel(false);
+
+		try {
+			Thread.sleep(1000);
+		} catch (InterruptedException e) {
+		}
+
+		promise.then(new DoneCallback<String>() {
+			@Override
+			public void onDone(String result) {
+				Assert.fail("Shouldn't be called, because task was cancelled");
+			}
+		});
+
+		Assert.assertTrue(deferredFutureTask.isCancelled());
+	}
+}


### PR DESCRIPTION
Hey jdeferred team,

I really like your library. 
When calling deferredFutureTask.cancel(false) or even with true. The call will always throw a CancellationException because it won't return after checking the cancelled state. So, the get method gets called which actually throws the CancellationException for a reason. 

I attached a fix and a test for it.