### PR TITLE
fix: Add android compatibility on core library

### DIFF
--- a/subprojects/jdeferred-core/jdeferred-core.gradle
+++ b/subprojects/jdeferred-core/jdeferred-core.gradle
@@ -19,6 +19,11 @@ apply plugin: 'osgi'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
+tasks.withType(JavaCompile) {
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
+}
+
 dependencies {
     compile "org.slf4j:slf4j-api:$slf4jVersion"
     testCompile "junit:junit:$junitVersion"


### PR DESCRIPTION
Since `jdeferred-android` is dependant on `jdeferred-core`,  the latter has to be built under the same version of java as well.

Related to #101 