### PR TITLE
Adding support for whenSettled to DeferredManager (Promise.allSettled)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ target/
 *.iws
 .idea/
 build/
+
+# Local configuration file (sdk path, etc)
+local.properties

--- a/local.properties
+++ b/local.properties
@@ -1,1 +1,0 @@
-sdk.dir = ./android-sdk

--- a/subprojects/jdeferred-android/jdeferred-android.gradle
+++ b/subprojects/jdeferred-android/jdeferred-android.gradle
@@ -20,7 +20,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -38,14 +38,14 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 16
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
     lintOptions {
         abortOnError false
     }
     defaultConfig {
          minSdkVersion 15
-         targetSdkVersion 19
+         targetSdkVersion 26
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_6

--- a/subprojects/jdeferred-android/src/androidTest/java/org/jdeferred/android/test/AndroidDeferredManagerTest.java
+++ b/subprojects/jdeferred-android/src/androidTest/java/org/jdeferred/android/test/AndroidDeferredManagerTest.java
@@ -9,7 +9,7 @@ import org.jdeferred.android.DeferredAsyncTask;
 import android.test.AndroidTestCase;
 
 public class AndroidDeferredManagerTest extends AndroidTestCase {
-	protected AndroidDeferredManager dm = new AndroidDeferredManager();
+	protected final AndroidDeferredManager dm = new AndroidDeferredManager();
 
 	public void testDeferredAsyncTask() {
 		final ValueHolder<String> backgroundThreadGroupName = new ValueHolder<String>();

--- a/subprojects/jdeferred-android/src/main/AndroidManifest.xml
+++ b/subprojects/jdeferred-android/src/main/AndroidManifest.xml
@@ -18,8 +18,4 @@
     package="org.jdeferred.android"
     android:versionCode="1"
     android:versionName="1.2.0" >
-    
-    <uses-sdk
-        android:minSdkVersion="8"
-        android:targetSdkVersion="19" />
 </manifest>

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidAlwaysCallback.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidAlwaysCallback.java
@@ -1,22 +1,23 @@
-/*******************************************************************************
+/*
  * Copyright 2013 Ray Tsang
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.jdeferred.android;
 
 import org.jdeferred.AlwaysCallback;
 
-public interface AndroidAlwaysCallback<D, R> extends AlwaysCallback<D, R>, AndroidExecutionScopeable {
+public interface AndroidAlwaysCallback<D, R>
+        extends AlwaysCallback<D, R>, AndroidExecutionScopeable {
 
 }

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
@@ -15,6 +15,7 @@
  */
 package org.jdeferred.android;
 
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
@@ -48,7 +48,7 @@ import android.os.Build;
  *
  */
 public class AndroidDeferredManager extends DefaultDeferredManager {
-	private static Void[] EMPTY_PARAMS = new Void[]{};
+	private static final Void[] EMPTY_PARAMS = new Void[]{};
 	
 	public AndroidDeferredManager() {
 		super();
@@ -85,12 +85,8 @@ public class AndroidDeferredManager extends DefaultDeferredManager {
 		
 		if (task.getStartPolicy() == StartPolicy.AUTO 
 				|| (task.getStartPolicy() == StartPolicy.DEFAULT && isAutoSubmit())) {
-			
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-				task.executeOnExecutor(getExecutorService(), EMPTY_PARAMS);
-			} else {
-				task.execute(EMPTY_PARAMS);
-			}
+
+			task.executeOnExecutor(getExecutorService(), EMPTY_PARAMS);
 		}
 		
 		return task.promise();

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
@@ -25,7 +25,9 @@ import org.jdeferred.Promise;
 import org.jdeferred.impl.DefaultDeferredManager;
 import org.jdeferred.multiple.MasterDeferredObject;
 import org.jdeferred.multiple.MasterProgress;
+import org.jdeferred.multiple.MultipleOutcomes;
 import org.jdeferred.multiple.MultipleResults;
+import org.jdeferred.multiple.OneOutcome;
 import org.jdeferred.multiple.OneReject;
 
 import android.annotation.SuppressLint;
@@ -175,6 +177,18 @@ public class AndroidDeferredManager extends DefaultDeferredManager {
 	public Promise<MultipleResults, OneReject, MasterProgress> when(Promise... promises) {
 		return new AndroidDeferredObject<MultipleResults, OneReject, MasterProgress>
 			(super.when(promises)).promise();
+	}
+
+	/**
+	 * Wraps {@link MasterDeferredObject} with {@link AndroidDeferredObject} so that callbacks can
+	 * be executed in UI thread.
+	 */
+	@SuppressWarnings({"rawtypes"})
+	@Override
+	public Promise<MultipleOutcomes<OneOutcome>, Void, MasterProgress> whenSettled(
+			Promise... promises) {
+		return new AndroidDeferredObject<MultipleOutcomes<OneOutcome>, Void, MasterProgress>
+				(super.whenSettled(promises)).promise();
 	}
 
 	/**

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
@@ -1,18 +1,18 @@
-/*******************************************************************************
+/*
  * Copyright 2013 Ray Tsang
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.jdeferred.android;
 
 import java.util.concurrent.Callable;
@@ -129,7 +129,7 @@ public class AndroidDeferredManager extends DefaultDeferredManager {
 	 * 	<li>{@link DeferredManager#when(Callable)}</li>
 	 *  <li>{@link DeferredManager#when(Callable...)}</li>
 	 *  <li>{@link DeferredManager#when(Runnable)}</li>
-	 *  <li>{@link DeferredManager#when(Runnable..)}</li>
+	 *  <li>{@link DeferredManager#when(Runnable...)}</li>
 	 *  <li>{@link DeferredManager#when(java.util.concurrent.Future)}</li>
 	 *  <li>{@link DeferredManager#when(java.util.concurrent.Future...)}</li>
 	 *  <li>{@link DeferredManager#when(org.jdeferred.DeferredRunnable...)}</li>

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
@@ -1,18 +1,18 @@
-/*******************************************************************************
+/*
  * Copyright 2013 Ray Tsang
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.jdeferred.android;
 
 import java.lang.reflect.Method;

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
@@ -109,7 +109,7 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 		} else {
 			super.triggerDone(callback, resolved);
 		}
-	};
+	}
 
 	protected void triggerFail(FailCallback<F> callback, F rejected) {
 		if (determineAndroidExecutionScope(callback) == AndroidExecutionScope.UI) {
@@ -118,7 +118,7 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 		} else {
 			super.triggerFail(callback, rejected);
 		}
-	};
+	}
 
 	protected void triggerProgress(ProgressCallback<P> callback, P progress) {
 		if (determineAndroidExecutionScope(callback) == AndroidExecutionScope.UI) {
@@ -127,7 +127,7 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 		} else {
 			super.triggerProgress(callback, progress);
 		}
-	};
+	}
 
 	protected void triggerAlways(AlwaysCallback<D, F> callback, State state,
 			D resolve, F reject) {
@@ -137,7 +137,7 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 		} else {
 			super.triggerAlways(callback, state, resolve, reject);
 		}
-	};
+	}
 
 	protected <Callback> void executeInUiThread(int what, Callback callback,
 			State state, D resolve, F reject, P progress) {

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDoneCallback.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDoneCallback.java
@@ -1,18 +1,18 @@
-/*******************************************************************************
+/*
  * Copyright 2013 Ray Tsang
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.jdeferred.android;
 
 import org.jdeferred.DoneCallback;

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidExecutionScope.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidExecutionScope.java
@@ -1,18 +1,18 @@
-/*******************************************************************************
+/*
  * Copyright 2013 Ray Tsang
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.jdeferred.android;
 
 public enum AndroidExecutionScope {

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidExecutionScopeable.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidExecutionScopeable.java
@@ -1,18 +1,18 @@
-/*******************************************************************************
+/*
  * Copyright 2013 Ray Tsang
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.jdeferred.android;
 
 /**

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidExecutionScopeable.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidExecutionScopeable.java
@@ -26,5 +26,5 @@ package org.jdeferred.android;
  *
  */
 public interface AndroidExecutionScopeable {
-	public AndroidExecutionScope getExecutionScope();
+	AndroidExecutionScope getExecutionScope();
 }

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidFailCallback.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidFailCallback.java
@@ -1,18 +1,18 @@
-/*******************************************************************************
+/*
  * Copyright 2013 Ray Tsang
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.jdeferred.android;
 
 import org.jdeferred.FailCallback;

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidProgressCallback.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidProgressCallback.java
@@ -1,18 +1,18 @@
-/*******************************************************************************
+/*
  * Copyright 2013 Ray Tsang
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.jdeferred.android;
 
 import org.jdeferred.ProgressCallback;

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/DeferredAsyncTask.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/DeferredAsyncTask.java
@@ -59,8 +59,8 @@ public abstract class DeferredAsyncTask<Params, Progress, Result> extends AsyncT
 	
 	protected final void onCancelled(Result result) {
 		deferred.reject(new CancellationException());
-	};
-	
+	}
+
 	@Override
 	protected final void onPostExecute(Result result) {
 		if (throwable != null) {
@@ -80,8 +80,8 @@ public abstract class DeferredAsyncTask<Params, Progress, Result> extends AsyncT
 			log.warn("There were multiple progress values.  Only the first one was used!");
 			deferred.notify(values[0]);
 		}
-	};
-	
+	}
+
 	protected final Result doInBackground(Params ... params) {
 		try {
 			return doInBackgroundSafe(params);
@@ -89,8 +89,8 @@ public abstract class DeferredAsyncTask<Params, Progress, Result> extends AsyncT
 			throwable = e;
 			return null;
 		}
-	};
-	
+	}
+
 	protected abstract Result doInBackgroundSafe(Params ... params) throws Exception;
 	
 	@SuppressWarnings("unchecked")

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/DeferredAsyncTask.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/DeferredAsyncTask.java
@@ -1,18 +1,18 @@
-/*******************************************************************************
+/*
  * Copyright 2013 Ray Tsang
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.jdeferred.android;
 
 import java.util.concurrent.CancellationException;

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/annotation/ExecutionScope.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/annotation/ExecutionScope.java
@@ -1,18 +1,18 @@
-/*******************************************************************************
+/*
  * Copyright 2013 Ray Tsang
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.jdeferred.android.annotation;
 
 import java.lang.annotation.ElementType;

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/AlwaysCallback.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/AlwaysCallback.java
@@ -18,5 +18,5 @@ package org.jdeferred;
 import org.jdeferred.Promise.State;
 
 public interface AlwaysCallback<D, R> {
-	public void onAlways(final State state, final D resolved, final R rejected);
+	void onAlways(final State state, final D resolved, final R rejected);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/Deferred.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/Deferred.java
@@ -51,9 +51,6 @@ public interface Deferred<D, F, P> extends Promise<D, F, P> {
 	 * 
 	 * </code>
 	 * </pre>
-	 * 
-	 * @param resolve
-	 * @return
 	 */
 	Deferred<D, F, P> resolve(final D resolve);
 
@@ -76,9 +73,6 @@ public interface Deferred<D, F, P> extends Promise<D, F, P> {
 	 * 
 	 * </code>
 	 * </pre>
-	 * 
-	 * @param resolve
-	 * @return
 	 */
 	Deferred<D, F, P> reject(final F reject);
 
@@ -101,16 +95,11 @@ public interface Deferred<D, F, P> extends Promise<D, F, P> {
 	 * 
 	 * </code>
 	 * </pre>
-	 * 
-	 * @param resolve
-	 * @return
 	 */
 	Deferred<D, F, P> notify(final P progress);
 
 	/**
 	 * Return an {@link Promise} instance (i.e., an observer).  You can register callbacks in this observer.
-	 * 
-	 * @return
 	 */
 	Promise<D, F, P> promise();
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredCallable.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredCallable.java
@@ -44,7 +44,6 @@ public abstract class DeferredCallable<D, P> implements Callable<D> {
 	
 	/**
 	 * @see Deferred#notify(Object)
-	 * @param progress
 	 */
 	protected void notify(P progress) {
 		deferred.notify(progress);

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredFutureTask.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredFutureTask.java
@@ -82,7 +82,7 @@ public class DeferredFutureTask<D, P> extends FutureTask<D> {
 			}
 			D result = get();
 			deferred.resolve(result);
-		} catch (InterruptedException e) {
+		} catch (InterruptedException ignored) {
 		} catch (ExecutionException e) {
 			deferred.reject(e.getCause());
 		}

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
@@ -91,9 +91,6 @@ public interface DeferredManager {
 	
 	/**
 	 * Simply returns the promise.
-	 * 
-	 * @param promise
-	 * @return promise
 	 */
 	public abstract <D, F, P> Promise<D, F, P> when(Promise<D, F, P> promise);
 
@@ -101,7 +98,6 @@ public interface DeferredManager {
 	 * Wraps {@link Runnable} with {@link DeferredFutureTask}.
 	 * 
 	 * @see #when(DeferredFutureTask)
-	 * @param runnable
 	 * @return {@link #when(DeferredFutureTask)}
 	 */
 	public abstract Promise<Void, Throwable, Void> when(Runnable runnable);
@@ -110,7 +106,6 @@ public interface DeferredManager {
 	 * Wraps {@link Callable} with {@link DeferredFutureTask}
 	 * 
 	 * @see #when(DeferredFutureTask)
-	 * @param callable
 	 * @return {@link #when(DeferredFutureTask)}
 	 */
 	public abstract <D> Promise<D, Throwable, Void> when(Callable<D> callable);
@@ -118,8 +113,7 @@ public interface DeferredManager {
 	/**
 	 * Wraps {@link Future} and waits for {@link Future#get()} to return a result
 	 * in the background.
-	 *  
-	 * @param future
+	 *
 	 * @return {@link #when(Callable)}
 	 */
 	public abstract <D> Promise<D, Throwable, Void> when(Future<D> future);
@@ -128,7 +122,6 @@ public interface DeferredManager {
 	 * Wraps {@link DeferredRunnable} with {@link DeferredFutureTask}
 	 * 
 	 * @see #when(DeferredFutureTask)
-	 * @param runnable
 	 * @return {@link #when(DeferredFutureTask)}
 	 */
 	public abstract <P> Promise<Void, Throwable, P> when(
@@ -138,7 +131,6 @@ public interface DeferredManager {
 	 * Wraps {@link DeferredCallable} with {@link DeferredFutureTask}
 	 * 
 	 * @see #when(DeferredFutureTask)
-	 * @param callable
 	 * @return {@link #when(DeferredFutureTask)}
 	 */
 	public abstract <D, P> Promise<D, Throwable, P> when(
@@ -147,8 +139,7 @@ public interface DeferredManager {
 	/**
 	 * May or may not submit {@link DeferredFutureTask} for execution. See
 	 * implementation documentation.
-	 * 
-	 * @param task
+	 *
 	 * @return {@link DeferredFutureTask#promise()}
 	 */
 	public abstract <D, P> Promise<D, Throwable, P> when(
@@ -178,8 +169,7 @@ public interface DeferredManager {
 
 	/**
 	 * Wraps {@link Runnable} with {@link DeferredFutureTask}
-	 * 
-	 * @param runnables
+	 *
 	 * @return {@link #when(DeferredFutureTask...)}
 	 */
 	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(
@@ -187,8 +177,7 @@ public interface DeferredManager {
 
 	/**
 	 * Wraps {@link Callable} with {@link DeferredFutureTask}
-	 * 
-	 * @param callables
+	 *
 	 * @return {@link #when(DeferredFutureTask...)}
 	 */
 	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(
@@ -196,8 +185,7 @@ public interface DeferredManager {
 
 	/**
 	 * Wraps {@link DeferredRunnable} with {@link DeferredFutureTask}
-	 * 
-	 * @param runnables
+	 *
 	 * @return {@link #when(DeferredFutureTask...)}
 	 */
 	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(
@@ -205,8 +193,7 @@ public interface DeferredManager {
 
 	/**
 	 * Wraps {@link DeferredCallable} with {@link DeferredFutureTask}
-	 * 
-	 * @param callables
+	 *
 	 * @return {@link #when(DeferredFutureTask...)}
 	 */
 	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(
@@ -215,8 +202,7 @@ public interface DeferredManager {
 	/**
 	 * May or may not submit {@link DeferredFutureTask} for execution. See
 	 * implementation documentation.
-	 * 
-	 * @param tasks
+	 *
 	 * @return {@link #when(Promise...)}
 	 */
 	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
@@ -21,9 +21,7 @@ import java.util.concurrent.Future;
 import org.jdeferred.impl.DefaultDeferredManager;
 import org.jdeferred.multiple.MasterDeferredObject;
 import org.jdeferred.multiple.MasterProgress;
-import org.jdeferred.multiple.MultipleOutcomes;
 import org.jdeferred.multiple.MultipleResults;
-import org.jdeferred.multiple.OneOutcome;
 import org.jdeferred.multiple.OneReject;
 
 /**

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
@@ -146,8 +146,9 @@ public interface DeferredManager {
 			DeferredFutureTask<D, P> task);
 
 	/**
-	 * This will return a special Promise called {@link MasterDeferredObject}. In
-	 * short,
+	 * This will return a special Promise called {@link MasterDeferredObject}.
+	 * Equivalent to Promise.all in Javascript.
+	 * In short,
 	 * <ul>
 	 * <li>{@link Promise#done(DoneCallback)} will be triggered if all promises
 	 * resolves (i.e., all finished successfully).</li>
@@ -160,11 +161,33 @@ public interface DeferredManager {
 	 * {@link Promise#done(DoneCallback)} or {@link Promise#fail(FailCallback)}
 	 * would be triggered</li>
 	 * </ul>
-	 * 
-	 * @param promises
+	 *
+	 * @param promises the {@link Promise}s that will be processed
 	 * @return {@link MasterDeferredObject}
 	 */
 	Promise<MultipleResults, OneReject, MasterProgress> when(
+			Promise... promises);
+
+	/**
+	 * This will return a special Promise called {@link MasterDeferredObject}.
+	 * Equivalent to Promise.allSettled in Javascript.
+	 * In short,
+	 * <ul>
+	 * <li>{@link Promise#done(DoneCallback)} will be triggered if all promises
+	 * resolve or reject (i.e., all finished successfully or otherwise).</li>
+	 * <li>{@link Promise#fail(FailCallback)} will never be triggered.</li>
+	 * <li>{@link Promise#progress(ProgressCallback)} will be triggered whenever
+	 * one promise resolves or rejects, or whenever a promise was notified
+	 * progress.</li>
+	 * <li>{@link Promise#always(AlwaysCallback)} will be triggered whenever
+	 * {@link Promise#done(DoneCallback)} or {@link Promise#fail(FailCallback)}
+	 * would be triggered</li>
+	 * </ul>
+	 *
+	 * @param promises the {@link Promise}s that will be processed
+	 * @return {@link MasterDeferredObject}
+	 */
+	Promise<MultipleOutcomes<OneOutcome>, Void, MasterProgress> whenSettled(
 			Promise... promises);
 
 	/**

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
@@ -21,7 +21,9 @@ import java.util.concurrent.Future;
 import org.jdeferred.impl.DefaultDeferredManager;
 import org.jdeferred.multiple.MasterDeferredObject;
 import org.jdeferred.multiple.MasterProgress;
+import org.jdeferred.multiple.MultipleOutcomes;
 import org.jdeferred.multiple.MultipleResults;
+import org.jdeferred.multiple.OneOutcome;
 import org.jdeferred.multiple.OneReject;
 
 /**
@@ -61,7 +63,7 @@ import org.jdeferred.multiple.OneReject;
  */
 @SuppressWarnings({ "rawtypes" })
 public interface DeferredManager {
-	public static enum StartPolicy {
+	enum StartPolicy {
 		/**
 		 * Let Deferred Manager to determine whether to start the task at its own
 		 * discretion.
@@ -92,7 +94,7 @@ public interface DeferredManager {
 	/**
 	 * Simply returns the promise.
 	 */
-	public abstract <D, F, P> Promise<D, F, P> when(Promise<D, F, P> promise);
+	<D, F, P> Promise<D, F, P> when(Promise<D, F, P> promise);
 
 	/**
 	 * Wraps {@link Runnable} with {@link DeferredFutureTask}.
@@ -100,7 +102,7 @@ public interface DeferredManager {
 	 * @see #when(DeferredFutureTask)
 	 * @return {@link #when(DeferredFutureTask)}
 	 */
-	public abstract Promise<Void, Throwable, Void> when(Runnable runnable);
+	Promise<Void, Throwable, Void> when(Runnable runnable);
 
 	/**
 	 * Wraps {@link Callable} with {@link DeferredFutureTask}
@@ -108,7 +110,7 @@ public interface DeferredManager {
 	 * @see #when(DeferredFutureTask)
 	 * @return {@link #when(DeferredFutureTask)}
 	 */
-	public abstract <D> Promise<D, Throwable, Void> when(Callable<D> callable);
+	<D> Promise<D, Throwable, Void> when(Callable<D> callable);
 	
 	/**
 	 * Wraps {@link Future} and waits for {@link Future#get()} to return a result
@@ -116,7 +118,7 @@ public interface DeferredManager {
 	 *
 	 * @return {@link #when(Callable)}
 	 */
-	public abstract <D> Promise<D, Throwable, Void> when(Future<D> future);
+	<D> Promise<D, Throwable, Void> when(Future<D> future);
 
 	/**
 	 * Wraps {@link DeferredRunnable} with {@link DeferredFutureTask}
@@ -124,7 +126,7 @@ public interface DeferredManager {
 	 * @see #when(DeferredFutureTask)
 	 * @return {@link #when(DeferredFutureTask)}
 	 */
-	public abstract <P> Promise<Void, Throwable, P> when(
+	<P> Promise<Void, Throwable, P> when(
 			DeferredRunnable<P> runnable);
 
 	/**
@@ -133,7 +135,7 @@ public interface DeferredManager {
 	 * @see #when(DeferredFutureTask)
 	 * @return {@link #when(DeferredFutureTask)}
 	 */
-	public abstract <D, P> Promise<D, Throwable, P> when(
+	<D, P> Promise<D, Throwable, P> when(
 			DeferredCallable<D, P> callable);
 
 	/**
@@ -142,7 +144,7 @@ public interface DeferredManager {
 	 *
 	 * @return {@link DeferredFutureTask#promise()}
 	 */
-	public abstract <D, P> Promise<D, Throwable, P> when(
+	<D, P> Promise<D, Throwable, P> when(
 			DeferredFutureTask<D, P> task);
 
 	/**
@@ -164,7 +166,7 @@ public interface DeferredManager {
 	 * @param promises
 	 * @return {@link MasterDeferredObject}
 	 */
-	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(
+	Promise<MultipleResults, OneReject, MasterProgress> when(
 			Promise... promises);
 
 	/**
@@ -172,7 +174,7 @@ public interface DeferredManager {
 	 *
 	 * @return {@link #when(DeferredFutureTask...)}
 	 */
-	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(
+	Promise<MultipleResults, OneReject, MasterProgress> when(
 			Runnable... runnables);
 
 	/**
@@ -180,7 +182,7 @@ public interface DeferredManager {
 	 *
 	 * @return {@link #when(DeferredFutureTask...)}
 	 */
-	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(
+	Promise<MultipleResults, OneReject, MasterProgress> when(
 			Callable<?>... callables);
 
 	/**
@@ -188,7 +190,7 @@ public interface DeferredManager {
 	 *
 	 * @return {@link #when(DeferredFutureTask...)}
 	 */
-	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(
+	Promise<MultipleResults, OneReject, MasterProgress> when(
 			DeferredRunnable<?>... runnables);
 
 	/**
@@ -196,7 +198,7 @@ public interface DeferredManager {
 	 *
 	 * @return {@link #when(DeferredFutureTask...)}
 	 */
-	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(
+	Promise<MultipleResults, OneReject, MasterProgress> when(
 			DeferredCallable<?, ?>... callables);
 
 	/**
@@ -205,10 +207,10 @@ public interface DeferredManager {
 	 *
 	 * @return {@link #when(Promise...)}
 	 */
-	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(
+	Promise<MultipleResults, OneReject, MasterProgress> when(
 			DeferredFutureTask<?, ?>... tasks);
 	
-	public abstract Promise<MultipleResults, OneReject, MasterProgress> when(
-			Future<?> ... futures);
+	Promise<MultipleResults, OneReject, MasterProgress> when(
+			Future<?>... futures);
 
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredRunnable.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredRunnable.java
@@ -41,7 +41,6 @@ public abstract class DeferredRunnable<P> implements Runnable {
 	
 	/**
 	 * @see Deferred#notify(Object)
-	 * @param progress
 	 */
 	protected void notify(P progress) {
 		deferred.notify(progress);

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DoneCallback.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DoneCallback.java
@@ -23,5 +23,5 @@ package org.jdeferred;
  * @param <D>
  */
 public interface DoneCallback<D> {
-	public void onDone(final D result);
+	void onDone(final D result);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DoneFilter.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DoneFilter.java
@@ -19,8 +19,8 @@ package org.jdeferred;
  * @see Promise#then(DoneFilter, FailFilter)
  * @author Ray Tsang
  *
- * @param <P> Type of the input
- * @param <P_OUT> Type of the output from this filter
+ * @param <D> Type of the input
+ * @param <D_OUT> Type of the output from this filter
  */
 public interface DoneFilter<D, D_OUT> {
 	public D_OUT filterDone(final D result);

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DoneFilter.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DoneFilter.java
@@ -23,5 +23,5 @@ package org.jdeferred;
  * @param <D_OUT> Type of the output from this filter
  */
 public interface DoneFilter<D, D_OUT> {
-	public D_OUT filterDone(final D result);
+	D_OUT filterDone(final D result);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DonePipe.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DonePipe.java
@@ -27,6 +27,5 @@ package org.jdeferred;
  * @see Deferred#notify(Object)
  */
 public interface DonePipe<D, D_OUT, F_OUT, P_OUT> {
-
 	Promise<D_OUT, F_OUT, P_OUT> pipeDone(final D result);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DonePipe.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DonePipe.java
@@ -16,12 +16,17 @@
 package org.jdeferred;
 
 /**
- * @see Promise#then(DonePipe, FailPipe)
+ * @param <D>     Type of this {@link DonePipe}'s input
+ * @param <D_OUT> Type used for {@link Promise#done(DoneCallback)}
+ * @param <F_OUT> Type used for {@link Promise#fail(FailCallback)}
+ * @param <P_OUT> Type used for {@link Promise#progress(ProgressCallback)}
  * @author Ray Tsang
- *
- * @param <P> Type of the input
- * @param <P_OUT> Type of the output from this filter
+ * @see Promise#then(DonePipe, FailPipe)
+ * @see Deferred#resolve(Object)
+ * @see Deferred#reject(Object)
+ * @see Deferred#notify(Object)
  */
 public interface DonePipe<D, D_OUT, F_OUT, P_OUT> {
+
 	public Promise<D_OUT, F_OUT, P_OUT> pipeDone(final D result);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DonePipe.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DonePipe.java
@@ -28,5 +28,5 @@ package org.jdeferred;
  */
 public interface DonePipe<D, D_OUT, F_OUT, P_OUT> {
 
-	public Promise<D_OUT, F_OUT, P_OUT> pipeDone(final D result);
+	Promise<D_OUT, F_OUT, P_OUT> pipeDone(final D result);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailCallback.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailCallback.java
@@ -23,5 +23,5 @@ package org.jdeferred;
  * @param <F>
  */
 public interface FailCallback<F> {
-	public void onFail(final F result);
+	void onFail(final F result);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailFilter.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailFilter.java
@@ -19,8 +19,8 @@ package org.jdeferred;
  * @see Promise#then(DoneFilter, FailFilter)
  * @author Ray Tsang
  *
- * @param <P> Type of the input
- * @param <P_OUT> Type of the output from this filter
+ * @param <F> Type of the input
+ * @param <F_OUT> Type of the output from this filter
  */
 public interface FailFilter<F, F_OUT> {
 	public F_OUT filterFail(final F result);

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailFilter.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailFilter.java
@@ -23,5 +23,5 @@ package org.jdeferred;
  * @param <F_OUT> Type of the output from this filter
  */
 public interface FailFilter<F, F_OUT> {
-	public F_OUT filterFail(final F result);
+	F_OUT filterFail(final F result);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailPipe.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailPipe.java
@@ -27,5 +27,5 @@ package org.jdeferred;
  * @see Deferred#notify(Object)
  */
 public interface FailPipe<F, D_OUT, F_OUT, P_OUT> {
-	public Promise<D_OUT, F_OUT, P_OUT> pipeFail(final F result);
+	Promise<D_OUT, F_OUT, P_OUT> pipeFail(final F result);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailPipe.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailPipe.java
@@ -16,11 +16,15 @@
 package org.jdeferred;
 
 /**
- * @see Promise#then(DonePipe, FailPipe)
+ * @param <F>     Type of this {@link FailPipe}'s input
+ * @param <D_OUT> Type used for {@link Promise#done(DoneCallback)}
+ * @param <F_OUT> Type used for {@link Promise#fail(FailCallback)}
+ * @param <P_OUT> Type used for {@link Promise#progress(ProgressCallback)}
  * @author Ray Tsang
- *
- * @param <P> Type of the input
- * @param <P_OUT> Type of the output from this filter
+ * @see Promise#then(DonePipe, FailPipe)
+ * @see Deferred#resolve(Object)
+ * @see Deferred#reject(Object)
+ * @see Deferred#notify(Object)
  */
 public interface FailPipe<F, D_OUT, F_OUT, P_OUT> {
 	public Promise<D_OUT, F_OUT, P_OUT> pipeFail(final F result);

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressCallback.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressCallback.java
@@ -23,5 +23,5 @@ package org.jdeferred;
  * @param <P>
  */
 public interface ProgressCallback<P> {
-	public void onProgress(final P progress);
+	void onProgress(final P progress);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressFilter.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressFilter.java
@@ -23,5 +23,5 @@ package org.jdeferred;
  * @param <P_OUT> Type of the output from this filter
  */
 public interface ProgressFilter<P, P_OUT> {
-	public P_OUT filterProgress(final P progress);
+	P_OUT filterProgress(final P progress);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressPipe.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressPipe.java
@@ -23,5 +23,5 @@ package org.jdeferred;
  * @param <P_OUT> Type of the output from this filter
  */
 public interface ProgressPipe<P, D_OUT, F_OUT, P_OUT> {
-	public Promise<D_OUT, F_OUT, P_OUT> pipeProgress(final P result);
+	Promise<D_OUT, F_OUT, P_OUT> pipeProgress(final P result);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressPipe.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressPipe.java
@@ -16,7 +16,7 @@
 package org.jdeferred;
 
 /**
- * @see Promise#then(ProgressPipe, FailFilter)
+ * @see Promise#then(DonePipe, FailPipe, ProgressPipe)
  * @author Ray Tsang
  *
  * @param <P> Type of the input

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
@@ -79,19 +79,16 @@ public interface Promise<D, F, P> {
 
 	/**
 	 * @see State#PENDING
-	 * @return
 	 */
 	public boolean isPending();
 
 	/**
 	 * @see State#RESOLVED
-	 * @return
 	 */
 	public boolean isResolved();
 
 	/**
 	 * @see State#REJECTED
-	 * @return
 	 */
 	public boolean isRejected();
 
@@ -99,7 +96,6 @@ public interface Promise<D, F, P> {
 	 * Equivalent to {@link #done(DoneCallback)}
 	 * 
 	 * @param doneCallback {@link #done(DoneCallback)}
-	 * @return
 	 */
 	public Promise<D, F, P> then(DoneCallback<D> doneCallback);
 
@@ -107,7 +103,6 @@ public interface Promise<D, F, P> {
 	 * Equivalent to {@link #done(DoneCallback)} and then {@link FailCallback}
 	 * @param doneCallback {@link #done(DoneCallback)}
 	 * @param failCallback {@link #fail(FailCallback)}
-	 * @return
 	 */
 	public Promise<D, F, P> then(DoneCallback<D> doneCallback,
 			FailCallback<F> failCallback);
@@ -118,7 +113,6 @@ public interface Promise<D, F, P> {
 	 * @param doneCallback {@link #done(DoneCallback)}
 	 * @param failCallback {@link #fail(FailCallback)}
 	 * @param progressCallback {@link #progress(ProgressCallback)}
-	 * @return
 	 */
 	public Promise<D, F, P> then(DoneCallback<D> doneCallback,
 			FailCallback<F> failCallback, ProgressCallback<P> progressCallback);
@@ -126,8 +120,6 @@ public interface Promise<D, F, P> {
 	/**
 	 * Equivalent to then(doneFilter, null, null)
 	 * @see {@link #then(DoneFilter, FailFilter, ProgressFilter)}
-	 * @param doneFilter
-	 * @return
 	 */
 	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DoneFilter<D, D_OUT> doneFilter);
@@ -135,9 +127,6 @@ public interface Promise<D, F, P> {
 	/**
 	 * Equivalent to then(doneFilter, failFilter, null)
 	 * @see {@link #then(DoneFilter, FailFilter, ProgressFilter)}
-	 * @param doneFilter
-	 * @param failFilter
-	 * @return
 	 */
 	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter);
@@ -165,31 +154,23 @@ public interface Promise<D, F, P> {
 	 * deferred.resolve(1); // prints 10
 	 * </code>
 	 * </pre>
-	 * 
-	 * @param doneFilter if null, use {@link NoOpDoneFilter}
-	 * @param failFilter if null, use {@link NoOpFailFilter}
-	 * @param progressFilter if null, use {@link NoOpProgressFilter}
-	 * @return
+	 *
+	 * @param doneFilter if null, use {@link org.jdeferred.impl.FilteredPromise.NoOpDoneFilter}
+	 * @param failFilter if null, use {@link org.jdeferred.impl.FilteredPromise.NoOpFailFilter}
+	 * @param progressFilter if null, use {@link org.jdeferred.impl.FilteredPromise.NoOpProgressFilter}
 	 */
 	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter,
 			ProgressFilter<P, P_OUT> progressFilter);
 	
 	/**
-	 * Equivalent to then(DonePipe, null, null) 
-	 * 
-	 * @param donePipe
-	 * @return
+	 * Equivalent to then(DonePipe, null, null)
 	 */
 	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe);
 	
 	/**
 	 * Equivalent to then(DonePipe, FailPipe, null)
-	 * 
-	 * @param donePipe
-	 * @param failPipe
-	 * @return
 	 */
 	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe, FailPipe<F, D_OUT, F_OUT, P_OUT> failPipe);
@@ -215,11 +196,6 @@ public interface Promise<D, F, P> {
 	 * .fail(...);
 	 * </code>
 	 * </pre>
-	 * 
-	 * @param donePipe
-	 * @param failPipe
-	 * @param progressPipe
-	 * @return
 	 */
 	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe, FailPipe<F, D_OUT, F_OUT, P_OUT> failPipe,
@@ -243,8 +219,6 @@ public interface Promise<D, F, P> {
 	 * </pre>
 	 * 
 	 * @see Deferred#resolve(Object)
-	 * @param callback
-	 * @return
 	 */
 	public Promise<D, F, P> done(DoneCallback<D> callback);
 	
@@ -266,8 +240,6 @@ public interface Promise<D, F, P> {
 	 * </pre>
 	 * 
 	 * @see Deferred#reject(Object)
-	 * @param callback
-	 * @return
 	 */
 	public Promise<D, F, P> fail(FailCallback<F> callback);
 	
@@ -294,8 +266,6 @@ public interface Promise<D, F, P> {
 	 * 
 	 * @see Deferred#resolve(Object)
 	 * @see Deferred#reject(Object)
-	 * @param callback
-	 * @return
 	 */
 	public Promise<D, F, P> always(AlwaysCallback<D, F> callback);
 	
@@ -317,25 +287,25 @@ public interface Promise<D, F, P> {
 	 * </pre>
 	 * 
 	 * @see Deferred#notify(Object)
-	 * @param callback
-	 * @return
 	 */
 	public Promise<D, F, P> progress(ProgressCallback<P> callback);
-	
+
 	/**
-	 * This method will wait as long as the State is Pending.  This method will fail fast
+	 * This method will wait as long as the State is Pending. This method will fail fast
 	 * when State is not Pending.
-	 * 
-	 * @throws InterruptedException
+	 *
+	 * @throws InterruptedException thrown when failing fast because {@link State} is no longer
+	 *                              {@link State#PENDING}
 	 */
 	public void waitSafely() throws InterruptedException;
-	
+
 	/**
 	 * This method will wait when the State is Pending, and return when timeout has reached.
 	 * This method will fail fast when State is not Pending.
-	 * 
+	 *
 	 * @param timeout the maximum time to wait in milliseconds
-	 * @throws InterruptedException
+	 * @throws InterruptedException thrown when failing fast because {@link State} is no longer
+	 *                              {@link State#PENDING}
 	 */
 	public void waitSafely(long timeout) throws InterruptedException;
 	

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
@@ -51,7 +51,7 @@ package org.jdeferred;
  *            Type used for {@link #progress(ProgressCallback)}
  */
 public interface Promise<D, F, P> {
-	public enum State {
+	enum State {
 		/**
 		 * The Promise is still pending - it could be created, submitted for execution,
 		 * or currently running, but not yet finished.
@@ -75,36 +75,36 @@ public interface Promise<D, F, P> {
 		RESOLVED
 	}
 
-	public State state();
+	State state();
 
 	/**
 	 * @see State#PENDING
 	 */
-	public boolean isPending();
+	boolean isPending();
 
 	/**
 	 * @see State#RESOLVED
 	 */
-	public boolean isResolved();
+	boolean isResolved();
 
 	/**
 	 * @see State#REJECTED
 	 */
-	public boolean isRejected();
+	boolean isRejected();
 
 	/**
 	 * Equivalent to {@link #done(DoneCallback)}
 	 * 
 	 * @param doneCallback {@link #done(DoneCallback)}
 	 */
-	public Promise<D, F, P> then(DoneCallback<D> doneCallback);
+	Promise<D, F, P> then(DoneCallback<D> doneCallback);
 
 	/**
 	 * Equivalent to {@link #done(DoneCallback)} and then {@link FailCallback}
 	 * @param doneCallback {@link #done(DoneCallback)}
 	 * @param failCallback {@link #fail(FailCallback)}
 	 */
-	public Promise<D, F, P> then(DoneCallback<D> doneCallback,
+	Promise<D, F, P> then(DoneCallback<D> doneCallback,
 			FailCallback<F> failCallback);
 
 	/**
@@ -114,21 +114,21 @@ public interface Promise<D, F, P> {
 	 * @param failCallback {@link #fail(FailCallback)}
 	 * @param progressCallback {@link #progress(ProgressCallback)}
 	 */
-	public Promise<D, F, P> then(DoneCallback<D> doneCallback,
+	Promise<D, F, P> then(DoneCallback<D> doneCallback,
 			FailCallback<F> failCallback, ProgressCallback<P> progressCallback);
 	
 	/**
 	 * Equivalent to then(doneFilter, null, null)
 	 * @see {@link #then(DoneFilter, FailFilter, ProgressFilter)}
 	 */
-	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
+	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DoneFilter<D, D_OUT> doneFilter);
 
 	/**
 	 * Equivalent to then(doneFilter, failFilter, null)
 	 * @see {@link #then(DoneFilter, FailFilter, ProgressFilter)}
 	 */
-	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
+	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter);
 
 	/**
@@ -159,20 +159,20 @@ public interface Promise<D, F, P> {
 	 * @param failFilter if null, use {@link org.jdeferred.impl.FilteredPromise.NoOpFailFilter}
 	 * @param progressFilter if null, use {@link org.jdeferred.impl.FilteredPromise.NoOpProgressFilter}
 	 */
-	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
+	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter,
 			ProgressFilter<P, P_OUT> progressFilter);
 	
 	/**
 	 * Equivalent to then(DonePipe, null, null)
 	 */
-	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
+	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe);
 	
 	/**
 	 * Equivalent to then(DonePipe, FailPipe, null)
 	 */
-	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
+	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe, FailPipe<F, D_OUT, F_OUT, P_OUT> failPipe);
 	
 	/**
@@ -197,7 +197,7 @@ public interface Promise<D, F, P> {
 	 * </code>
 	 * </pre>
 	 */
-	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
+	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
 			DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe, FailPipe<F, D_OUT, F_OUT, P_OUT> failPipe,
 			ProgressPipe<P, D_OUT, F_OUT, P_OUT> progressPipe);
 	
@@ -220,7 +220,7 @@ public interface Promise<D, F, P> {
 	 * 
 	 * @see Deferred#resolve(Object)
 	 */
-	public Promise<D, F, P> done(DoneCallback<D> callback);
+	Promise<D, F, P> done(DoneCallback<D> callback);
 	
 	/**
 	 * This method will register {@link FailCallback} so that when a Deferred object 
@@ -241,7 +241,7 @@ public interface Promise<D, F, P> {
 	 * 
 	 * @see Deferred#reject(Object)
 	 */
-	public Promise<D, F, P> fail(FailCallback<F> callback);
+	Promise<D, F, P> fail(FailCallback<F> callback);
 	
 	/**
 	 * This method will register {@link AlwaysCallback} so that when it's always triggered
@@ -267,7 +267,7 @@ public interface Promise<D, F, P> {
 	 * @see Deferred#resolve(Object)
 	 * @see Deferred#reject(Object)
 	 */
-	public Promise<D, F, P> always(AlwaysCallback<D, F> callback);
+	Promise<D, F, P> always(AlwaysCallback<D, F> callback);
 	
 	/**
 	 * This method will register {@link ProgressCallback} so that when a Deferred object 
@@ -288,7 +288,7 @@ public interface Promise<D, F, P> {
 	 * 
 	 * @see Deferred#notify(Object)
 	 */
-	public Promise<D, F, P> progress(ProgressCallback<P> callback);
+	Promise<D, F, P> progress(ProgressCallback<P> callback);
 
 	/**
 	 * This method will wait as long as the State is Pending. This method will fail fast
@@ -297,7 +297,7 @@ public interface Promise<D, F, P> {
 	 * @throws InterruptedException thrown when failing fast because {@link State} is no longer
 	 *                              {@link State#PENDING}
 	 */
-	public void waitSafely() throws InterruptedException;
+	void waitSafely() throws InterruptedException;
 
 	/**
 	 * This method will wait when the State is Pending, and return when timeout has reached.
@@ -307,6 +307,6 @@ public interface Promise<D, F, P> {
 	 * @throws InterruptedException thrown when failing fast because {@link State} is no longer
 	 *                              {@link State#PENDING}
 	 */
-	public void waitSafely(long timeout) throws InterruptedException;
+	void waitSafely(long timeout) throws InterruptedException;
 	
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
@@ -15,6 +15,7 @@
  */
 package org.jdeferred.impl;
 
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -136,11 +137,24 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		return when(promises);
 	}
 
+	public Promise<MultipleResults, OneReject, MasterProgress> when(List<Promise> promises) {
+		assertNotEmpty(promises);
+		Promise[] promiseArray = promises.toArray(new Promise[promises.size()]);
+		return when(promiseArray);
+	}
+
 	@Override
 	public Promise<MultipleResults, OneReject, MasterProgress> when(Promise... promises) {
 		assertNotEmpty(promises);
 		MultipleResults results = new MultipleResults(promises.length);
 		return new MasterDeferredObject<MultipleResults, OneReject>(results, promises).promise();
+	}
+
+	public Promise<MultipleOutcomes<OneOutcome>, Void, MasterProgress> whenSettled(
+			List<Promise> promises) {
+		assertNotEmpty(promises);
+		Promise[] promiseArray = promises.toArray(new Promise[promises.size()]);
+		return whenSettled(promiseArray);
 	}
 
 	@Override
@@ -225,5 +239,11 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		if (objects == null || objects.length == 0)
 			throw new IllegalArgumentException(
 					"Arguments is null or its length is empty");
-	}	
+	}
+
+	protected void assertNotEmpty(List list) {
+		if (list == null || list.size() == 0)
+			throw new IllegalArgumentException(
+					"Arguments is null or its length is empty");
+	}
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
@@ -200,8 +200,6 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			public D call() throws Exception {
 				try {
 					return future.get();
-				} catch (InterruptedException e) {
-					throw e;
 				} catch (ExecutionException e) {
 					if (e.getCause() instanceof Exception)
 						throw (Exception) e.getCause();

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
@@ -26,7 +26,9 @@ import org.jdeferred.DeferredRunnable;
 import org.jdeferred.Promise;
 import org.jdeferred.multiple.MasterProgress;
 import org.jdeferred.multiple.MasterDeferredObject;
+import org.jdeferred.multiple.MultipleOutcomes;
 import org.jdeferred.multiple.MultipleResults;
+import org.jdeferred.multiple.OneOutcome;
 import org.jdeferred.multiple.OneReject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,7 +139,17 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 	@Override
 	public Promise<MultipleResults, OneReject, MasterProgress> when(Promise... promises) {
 		assertNotEmpty(promises);
-		return new MasterDeferredObject(promises).promise();
+		MultipleResults results = new MultipleResults(promises.length);
+		return new MasterDeferredObject<MultipleResults, OneReject>(results, promises).promise();
+	}
+
+	@Override
+	public Promise<MultipleOutcomes<OneOutcome>, Void, MasterProgress> whenSettled(
+			Promise... promises) {
+		assertNotEmpty(promises);
+		MultipleOutcomes<OneOutcome> outcomes = new MultipleOutcomes<OneOutcome>(promises.length);
+		return new MasterDeferredObject<MultipleOutcomes<OneOutcome>, Void>(outcomes, promises)
+				.promise();
 	}
 
 	@Override

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
@@ -49,7 +49,6 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 	 * <li>{@link #when(DeferredRunnable)}</li>
 	 * <li>{@link #when(DeferredFutureTask))}</li>
 	 * </ul>
-	 * @return
 	 */
 	public abstract boolean isAutoSubmit();
 	
@@ -172,7 +171,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 	 * 	<li>{@link #when(Callable)}</li>
 	 *  <li>{@link #when(Callable...)}</li>
 	 *  <li>{@link #when(Runnable)}</li>
-	 *  <li>{@link #when(Runnable..)}</li>
+	 *  <li>{@link #when(Runnable...)}</li>
 	 *  <li>{@link #when(java.util.concurrent.Future)}</li>
 	 *  <li>{@link #when(java.util.concurrent.Future...)}</li>
 	 *  <li>{@link #when(org.jdeferred.DeferredRunnable...)}</li>

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
@@ -259,8 +259,6 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 				
 				if (timeout > 0 && ((System.currentTimeMillis() - startTime) >= timeout)) {
 					return;
-				} else {
-					continue; // keep looping
 				}
 			}
 		}

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DefaultDeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DefaultDeferredManager.java
@@ -22,13 +22,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A default implementation that runs deferred tasks using an {@link ExecutorService}.
- * Also, by default, deferred tasks are executed (submitted to the ExecutorService) automatically
- * when it's passed into {@link DeferredManager}'s when(...) methods.  This behavior can be changed
- * by setting {@link #setAutoSubmit(boolean)}.
- * 
- * @author Ray Tsang
+ * A default implementation that runs deferred tasks using an {@link ExecutorService}. Also, by
+ * default, deferred tasks are executed (submitted to the ExecutorService) automatically when it's
+ * passed into {@link org.jdeferred.DeferredManager}'s when(...) methods.  This behavior can be
+ * changed by setting {@link #setAutoSubmit(boolean)}.
  *
+ * @author Ray Tsang
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class DefaultDeferredManager extends AbstractDeferredManager {
@@ -39,7 +38,7 @@ public class DefaultDeferredManager extends AbstractDeferredManager {
 	 * {@link Runnable} or {@link Callable} are executed.
 	 */
 	public static final boolean DEFAULT_AUTO_SUBMIT = true;
-	
+
 	private final ExecutorService executorService;
 	private boolean autoSubmit = DEFAULT_AUTO_SUBMIT;
 
@@ -51,10 +50,6 @@ public class DefaultDeferredManager extends AbstractDeferredManager {
 		this.executorService = Executors.newCachedThreadPool();
 	}
 
-	/**
-	 * 
-	 * @param executorService
-	 */
 	public DefaultDeferredManager(ExecutorService executorService) {
 		this.executorService = executorService;
 	}
@@ -88,7 +83,7 @@ public class DefaultDeferredManager extends AbstractDeferredManager {
 	protected void submit(Runnable runnable) {
 		executorService.submit(runnable);
 	}
-	
+
 	@Override
 	protected void submit(Callable callable) {
 		executorService.submit(callable);
@@ -102,5 +97,5 @@ public class DefaultDeferredManager extends AbstractDeferredManager {
 	public void setAutoSubmit(boolean autoSubmit) {
 		this.autoSubmit = autoSubmit;
 	}
-	
+
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
@@ -49,8 +49,6 @@ public abstract class DelegatingPromise<D, F, P> implements Promise<D, F, P> {
 
     /**
      * Returns the delegate Promise wrapped by this Promise.
-     *
-     * @return
      */
     protected Promise<D, F, P> getDelegate() {
         return delegate;

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/FutureCallable.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/FutureCallable.java
@@ -30,8 +30,6 @@ public class FutureCallable<V> implements Callable<V> {
 	public V call() throws Exception {
 		try {
 			return future.get();
-		} catch (InterruptedException e) {
-			throw e;
 		} catch (ExecutionException e) {
 			if (e.getCause() instanceof Exception)
 				throw (Exception) e.getCause();

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/PipedPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/PipedPromise.java
@@ -15,7 +15,6 @@
  */
 package org.jdeferred.impl;
 
-import org.jdeferred.Deferred;
 import org.jdeferred.DoneCallback;
 import org.jdeferred.DonePipe;
 import org.jdeferred.FailCallback;

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MasterProgress.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MasterProgress.java
@@ -17,15 +17,15 @@ package org.jdeferred.multiple;
 
 /**
  * Progress indicating how many promises need to finish ({@link #total}),
- * and how many had already finish ({@link #fulfilled}).
- * @author Ray Tsang
+ * and how many have already finished successfully ({@link #done}) or failed ({@link #fail}).
  *
+ * @author Ray Tsang
  */
 public class MasterProgress {
 	private final int done;
 	private final int fail;
 	private final int total;
-	
+
 	public MasterProgress(int done, int fail, int total) {
 		super();
 		this.done = done;

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleOutcomes.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleOutcomes.java
@@ -15,15 +15,37 @@
  */
 package org.jdeferred.multiple;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 /**
  * Contains a list of {@link OneResult}.
  *
  * @author Ray Tsang
  */
-public class MultipleResults extends MultipleOutcomes<OneResult> {
+public class MultipleOutcomes<T extends OneOutcome> implements Iterable<T> {
 
-    public MultipleResults(int size) {
-        super(size);
+    protected final List<T> results;
+
+    public MultipleOutcomes(int size) {
+        this.results = new CopyOnWriteArrayList(new Object[size]);
+    }
+
+    protected void set(int index, T result) {
+        results.set(index, result);
+    }
+
+    public T get(int index) {
+        return results.get(index);
+    }
+
+    public Iterator<T> iterator() {
+        return results.iterator();
+    }
+
+    public int size() {
+        return results.size();
     }
 
     @Override

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneOutcome.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneOutcome.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2017 Enno Gottschalk
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,6 @@
  */
 package org.jdeferred.multiple;
 
-/**
- * Contains a list of {@link OneResult}.
- *
- * @author Ray Tsang
- */
-public class MultipleResults extends MultipleOutcomes<OneResult> {
+public interface OneOutcome {
 
-    public MultipleResults(int size) {
-        super(size);
-    }
-
-    @Override
-    public String toString() {
-        return "MultipleResults [results=" + results + "]";
-    }
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneReject.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneReject.java
@@ -23,7 +23,7 @@ import org.jdeferred.Promise;
  *
  */
 @SuppressWarnings("rawtypes")
-public class OneReject {
+public class OneReject implements OneOutcome {
 	private final int index;
 	private final Promise promise;
 	private final Object reject;

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneResult.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneResult.java
@@ -23,7 +23,7 @@ import org.jdeferred.Promise;
  *
  */
 @SuppressWarnings("rawtypes")
-public class OneResult {
+public class OneResult implements OneOutcome {
 	private final int index;
 	private final Promise promise;
 	private final Object result;

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/AbstractDeferredTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/AbstractDeferredTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractDeferredTest {
 		while (!deferredManager.isTerminated()) {
 			try {
 				deferredManager.awaitTermination(1, TimeUnit.SECONDS);
-			} catch (InterruptedException e) {
+			} catch (InterruptedException ignored) {
 			}
 		}
 	}

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
@@ -36,7 +36,7 @@ public class CancelTaskTest extends AbstractDeferredTest {
 					public String call() throws Exception {
 						try {
 							Thread.sleep(1000);
-						} catch (InterruptedException e) {
+						} catch (InterruptedException ignored) {
 						}
 
 						return "Hello";
@@ -49,7 +49,7 @@ public class CancelTaskTest extends AbstractDeferredTest {
 
 		try {
 			Thread.sleep(1000);
-		} catch (InterruptedException e) {
+		} catch (InterruptedException ignored) {
 		}
 
 		promise.then(new DoneCallback<String>() {

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/FilteredPromiseTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/FilteredPromiseTest.java
@@ -88,7 +88,7 @@ public class FilteredPromiseTest extends AbstractDeferredTest {
 				for (int i = 0; i < 10; i++) {
 					try {
 						Thread.sleep(200);
-					} catch (InterruptedException e) {
+					} catch (InterruptedException ignored) {
 					}
 					notify("HI");
 				}

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/MultiplePromisesTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/MultiplePromisesTest.java
@@ -46,7 +46,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public Integer call() {
 				try {
 					Thread.sleep(1000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				return 100;
@@ -55,7 +55,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public String call() {
 				try {
 					Thread.sleep(1000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				return "Hello";
@@ -82,7 +82,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public Integer call() {
 				try {
 					Thread.sleep(1000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				return 100;
@@ -91,7 +91,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public String call() {
 				try {
 					Thread.sleep(1000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				return "Hello";
@@ -129,7 +129,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public Integer call() {
 				try {
 					Thread.sleep(1000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				throw new RuntimeException("oops");
@@ -138,7 +138,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public String call() {
 				try {
 					Thread.sleep(1000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				return "Hello";
@@ -168,7 +168,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public Integer call() {
 				try {
 					Thread.sleep(1000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				return 100;
@@ -183,7 +183,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public String call() {
 				try {
 					Thread.sleep(1000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				return "Hello";
@@ -223,7 +223,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 				for (int i = 1; i <= 10; i++) {
 					try {
 						Thread.sleep(100);
-					} catch (InterruptedException e) {
+					} catch (InterruptedException ignored) {
 					}
 					notify(i);
 					sum += i;
@@ -240,7 +240,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 				for (int i = 1; i <= 3; i++) {
 					try {
 						Thread.sleep(30);
-					} catch (InterruptedException e) {
+					} catch (InterruptedException ignored) {
 					}
 					notify("R-" + i);
 				}
@@ -299,7 +299,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 		waitForCompletion();
 		try {
 			Thread.sleep(1000);
-		} catch (InterruptedException e) {
+		} catch (InterruptedException ignored) {
 		}
 		Assert.assertEquals(1, alwaysCounter.get());
 		Assert.assertEquals(1, doneCounter.get());
@@ -339,7 +339,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public Integer call() {
 				try {
 					Thread.sleep(1000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				return 100;
@@ -348,7 +348,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public String call() {
 				try {
 					Thread.sleep(2000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				return "Hello";
@@ -382,7 +382,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public Integer call() {
 				try {
 					Thread.sleep(1000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				return 100;
@@ -391,7 +391,7 @@ public class MultiplePromisesTest extends AbstractDeferredTest {
 			public String call() {
 				try {
 					Thread.sleep(2000);
-				} catch (InterruptedException e) {
+				} catch (InterruptedException ignored) {
 				}
 				
 				return "Hello";

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/SinglePromiseTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/SinglePromiseTest.java
@@ -188,7 +188,7 @@ public class SinglePromiseTest extends AbstractDeferredTest {
 				for (int i = 1; i <= 10; i++) {
 					try {
 						Thread.sleep(100);
-					} catch (InterruptedException e) {
+					} catch (InterruptedException ignored) {
 					}
 					notify(i);
 					sum += i;


### PR DESCRIPTION
Hey,

in addition to my codestyle PR I have added support for whenSettled to DeferredManager and its children. This is basically equivalent to Promise.allSettled. whenSettled waits for all Promises to either get resolved or rejected and then returns all results in the correct order.

Current functionality should remain untouched by my commits. 

I have compiled and tested jdeferred in my Android App project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jdeferred/jdeferred/118)
<!-- Reviewable:end -->
