### PR TITLE
Removed the try-catch closures from the callbacks invocations…

### DIFF
--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
@@ -94,12 +94,9 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	
 	protected void triggerDone(D resolved) {
 		for (DoneCallback<D> callback : doneCallbacks) {
-			try {
-				triggerDone(callback, resolved);
-			} catch (Exception e) {
-				log.error("an uncaught exception occured in a DoneCallback", e);
-			}
+			triggerDone(callback, resolved);
 		}
+
 		doneCallbacks.clear();
 	}
 	
@@ -109,11 +106,7 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	
 	protected void triggerFail(F rejected) {
 		for (FailCallback<F> callback : failCallbacks) {
-			try {
-				triggerFail(callback, rejected);
-			} catch (Exception e) {
-				log.error("an uncaught exception occured in a FailCallback", e);
-			}
+			triggerFail(callback, rejected);
 		}
 		failCallbacks.clear();
 	}
@@ -124,11 +117,7 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	
 	protected void triggerProgress(P progress) {
 		for (ProgressCallback<P> callback : progressCallbacks) {
-			try {
-				triggerProgress(callback, progress);
-			} catch (Exception e) {
-				log.error("an uncaught exception occured in a ProgressCallback", e);
-			}
+			triggerProgress(callback, progress);
 		}
 	}
 	
@@ -138,11 +127,7 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	
 	protected void triggerAlways(State state, D resolve, F reject) {
 		for (AlwaysCallback<D, F> callback : alwaysCallbacks) {
-			try {
-				triggerAlways(callback, state, resolve, reject);
-			} catch (Exception e) {
-				log.error("an uncaught exception occured in a AlwaysCallback", e);
-			}
+			triggerAlways(callback, state, resolve, reject);
 		}
 		alwaysCallbacks.clear();
 		


### PR DESCRIPTION
Hi!

Today i've had some troubles finding the real source of a bug in my application.

After a couple of looks and debugging i've realized that an exception was being thrown in a Promise's Done callback, and because the Done invocation is inside a try-catch statement the exception was never propagated and somehow was being 'muted' leading to strange behaviours.

Isn't it better to remove this generic try-catch statements from the done, fail, always and progress and let the developer handle the possible exceptions?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jdeferred/jdeferred/119)
<!-- Reviewable:end -->
