### PR TITLE
Cancelable callback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,11 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.7.1'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.1'
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.2'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
-        classpath 'net.nemerosa:versioning:2.5.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
+        classpath 'net.nemerosa:versioning:2.6.1'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,9 @@ project_bintray_repo = maven
 project_bintray_org  = jdeferred
 javadocFooter        = Copyright &copy; 2013-2017 Ray Tsang. All rights reserved.
 
-androidVersion    = 4.1.1.4
-awaitilityVersion = 3.0.0
-jacocoVersion     = 0.7.9
-junitVersion      = 4.12
-slf4jVersion      = 1.7.25
+androidVersion       = 4.1.1.4
+awaitilityVersion    = 3.0.0
+jacocoVersion        = 0.7.9
+junitVersion         = 4.12
+slf4jVersion         = 1.7.25
+JUnitParamsVersion   = 1.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group                = org.jdeferred
-version              = 1.2.7-SNAPSHOT
+version              = 2.0.0-SNAPSHOT
 sourceCompatibility  = 1.6
 targetCompatibility  = 1.6
 project_vendor       = jdeferred
@@ -9,10 +9,10 @@ project_scm          = https://github.com/jdeferred/jdeferred.git
 project_issues       = https://github.com/jdeferred/jdeferred/issues
 project_bintray_repo = maven
 project_bintray_org  = jdeferred
-javadocFooter        = Copyright &copy; 2013-2016 Ray Tsang. All rights reserved.
+javadocFooter        = Copyright &copy; 2013-2017 Ray Tsang. All rights reserved.
 
 androidVersion    = 4.1.1.4
-awaitilityVersion = 2.0.0
-jacocoVersion     = 0.7.7.201606060606
+awaitilityVersion = 3.0.0
+jacocoVersion     = 0.7.9
 junitVersion      = 4.12
-slf4jVersion      = 1.7.21
+slf4jVersion      = 1.7.25

--- a/gradle/code-coverage.gradle
+++ b/gradle/code-coverage.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/code-quality.gradle
+++ b/gradle/code-quality.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,6 @@ license {
         java = 'SLASHSTAR_STYLE'
         xml  = 'XML_STYLE'
     }
-    ext.year   = '2013-2016'
+    ext.year   = '2013-2017'
     ext.author = 'Ray Tsang'
 }

--- a/gradle/pom.gradle
+++ b/gradle/pom.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,14 +1,17 @@
-include 'subprojects/jdeferred-core'
-include 'subprojects/jdeferred-android'
-
 rootProject.name = 'jdeferred'
-rootProject.children.each { project ->
-    int slash = project.name.indexOf('/')
-    String fileBaseName = project.name[(slash + 1)..-1]
-    String projectDirName = project.name
-    project.name = fileBaseName
-    project.projectDir = new File(settingsDir, projectDirName)
-    project.buildFileName = "${fileBaseName}.gradle"
-    assert project.projectDir.isDirectory()
-    assert project.buildFile.isFile()
+
+def includeProject = { String projectDirName, String projectName ->
+    File baseDir = new File(settingsDir, projectDirName)
+    File projectDir = new File(baseDir, projectName)
+    String buildFileName = "${projectName}.gradle"
+
+    assert projectDir.isDirectory()
+    assert new File(projectDir, buildFileName).isFile()
+
+    include projectName
+    project(":${projectName}").projectDir    = projectDir
+    project(":${projectName}").buildFileName = buildFileName
 }
+
+includeProject 'subprojects', 'jdeferred-core'
+includeProject 'subprojects', 'jdeferred-android'

--- a/subprojects/jdeferred-android/jdeferred-android.gradle
+++ b/subprojects/jdeferred-android/jdeferred-android.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ dependencies {
 
     testCompile "junit:junit:$junitVersion"
     testCompile "org.slf4j:slf4j-jdk14:$slf4jVersion"
-    testCompile "org.awaitility:awaitility:$awaitilityVersion"
     testCompile "com.google.android:android:$androidVersion"
 }
 

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidAlwaysCallback.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidAlwaysCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
@@ -15,9 +15,11 @@
  */
 package org.jdeferred.android;
 
-import java.lang.reflect.Method;
-
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
 import org.jdeferred.AlwaysCallback;
+import org.jdeferred.CancelCallback;
 import org.jdeferred.Deferred;
 import org.jdeferred.DoneCallback;
 import org.jdeferred.FailCallback;
@@ -28,9 +30,7 @@ import org.jdeferred.impl.DeferredObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import android.os.Looper;
-import android.os.Handler;
-import android.os.Message;
+import java.lang.reflect.Method;
 
 public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 	private static final InternalHandler sHandler = new InternalHandler();
@@ -39,6 +39,7 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 	private static final int MESSAGE_POST_PROGRESS = 0x2;
 	private static final int MESSAGE_POST_FAIL = 0x3;
 	private static final int MESSAGE_POST_ALWAYS = 0x4;
+	private static final int MESSAGE_POST_CANCEL = 0x5;
 
 	final protected Logger log = LoggerFactory
 			.getLogger(AndroidDeferredObject.class);
@@ -84,20 +85,23 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 		public void handleMessage(Message msg) {
 			CallbackMessage<?, ?, ?, ?> result = (CallbackMessage<?, ?, ?, ?>) msg.obj;
 			switch (msg.what) {
-			case MESSAGE_POST_DONE:
-				((DoneCallback) result.callback).onDone(result.resolved);
-				break;
-			case MESSAGE_POST_PROGRESS:
-				((ProgressCallback) result.callback)
+				case MESSAGE_POST_DONE:
+					((DoneCallback) result.callback).onDone(result.resolved);
+					break;
+				case MESSAGE_POST_PROGRESS:
+					((ProgressCallback) result.callback)
 						.onProgress(result.progress);
-				break;
-			case MESSAGE_POST_FAIL:
-				((FailCallback) result.callback).onFail(result.rejected);
-				break;
-			case MESSAGE_POST_ALWAYS:
-				((AlwaysCallback) result.callback).onAlways(result.state,
+					break;
+				case MESSAGE_POST_FAIL:
+					((FailCallback) result.callback).onFail(result.rejected);
+					break;
+				case MESSAGE_POST_ALWAYS:
+					((AlwaysCallback) result.callback).onAlways(result.state,
 						result.resolved, result.rejected);
-				break;
+					break;
+				case MESSAGE_POST_CANCEL:
+					((CancelCallback) result.callback).onCancel();
+					break;
 			}
 		}
 	}
@@ -139,6 +143,15 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 		}
 	};
 
+	protected void triggerCancel(CancelCallback callback) {
+		if (determineAndroidExecutionScope(callback) == AndroidExecutionScope.UI) {
+			executeInUiThread(MESSAGE_POST_CANCEL, callback, State.PENDING,
+				null, null, null);
+		} else {
+			super.triggerCancel(callback);
+		}
+	};
+
 	protected <Callback> void executeInUiThread(int what, Callback callback,
 			State state, D resolve, F reject, P progress) {
 		Message message = sHandler.obtainMessage(what,
@@ -177,6 +190,8 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 			return determineAndroidExecutionScope(callback.getClass(), "onProgress", Object.class);
 		} else if (callback instanceof AlwaysCallback) {
 			return determineAndroidExecutionScope(callback.getClass(), "onAlways", State.class, Object.class, Object.class);
+		}else if (callback instanceof CancelCallback) {
+			return determineAndroidExecutionScope(callback.getClass(), "onCancel");
 		}
 		return scope == null ? defaultAndroidExecutionScope : scope;
 	}

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDoneCallback.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDoneCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidExecutionScope.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidExecutionScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidExecutionScopeable.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidExecutionScopeable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidFailCallback.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidFailCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidProgressCallback.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidProgressCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/DeferredAsyncTask.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/DeferredAsyncTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/annotation/ExecutionScope.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/annotation/ExecutionScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/jdeferred-core.gradle
+++ b/subprojects/jdeferred-core/jdeferred-core.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ dependencies {
     compile "org.slf4j:slf4j-api:$slf4jVersion"
     testCompile "junit:junit:$junitVersion"
     testCompile "org.slf4j:slf4j-jdk14:$slf4jVersion"
-    testCompile "org.awaitility:awaitility:$awaitilityVersion"
 }
 
 task sourcesJar(type: Jar) {

--- a/subprojects/jdeferred-core/jdeferred-core.gradle
+++ b/subprojects/jdeferred-core/jdeferred-core.gradle
@@ -28,6 +28,8 @@ dependencies {
     compile "org.slf4j:slf4j-api:$slf4jVersion"
     testCompile "junit:junit:$junitVersion"
     testCompile "org.slf4j:slf4j-jdk14:$slf4jVersion"
+    testCompile "org.awaitility:awaitility:$awaitilityVersion"
+    testCompile "pl.pragmatists:JUnitParams:$JUnitParamsVersion"
 }
 
 task sourcesJar(type: Jar) {

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/AlwaysCallback.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/AlwaysCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/CancelCallback.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/CancelCallback.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013-2017 Ray Tsang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdeferred;
+
+/**
+ * @see Deferred#cancel()
+ * @see Promise#cancel(CancelCallback)
+ * @author Andres Almiray
+ */
+public interface CancelCallback {
+	void onCancel();
+}

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/Deferred.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/Deferred.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/Deferred.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/Deferred.java
@@ -17,6 +17,8 @@ package org.jdeferred;
 
 import org.jdeferred.impl.DeferredObject;
 
+import java.util.concurrent.FutureTask;
+
 /**
  * Deferred interface to trigger an event (resolve, reject, notify).
  * Subsequently, this will allow Promise observers to listen in on the event
@@ -77,7 +79,7 @@ public interface Deferred<D, F, P> extends Promise<D, F, P> {
 	 * </code>
 	 * </pre>
 	 * 
-	 * @param resolve
+	 * @param reject
 	 * @return
 	 */
 	Deferred<D, F, P> reject(final F reject);
@@ -102,7 +104,7 @@ public interface Deferred<D, F, P> extends Promise<D, F, P> {
 	 * </code>
 	 * </pre>
 	 * 
-	 * @param resolve
+	 * @param progress
 	 * @return
 	 */
 	Deferred<D, F, P> notify(final P progress);
@@ -113,4 +115,29 @@ public interface Deferred<D, F, P> extends Promise<D, F, P> {
 	 * @return
 	 */
 	Promise<D, F, P> promise();
+
+	/**
+	 * This should be called when a task has been cancelled.
+	 *
+	 * <pre>
+	 * <code>
+	 * {@link Deferred} deferredObject = new {@link DeferredObject}();
+	 * {@link Promise} promise = deferredObject.promise();
+	 * promise.cancel(new {@link CancelCallback}() {
+	 *   public void onCancel() {
+	 *   	// Cancelled :(
+	 *   }
+	 * });
+	 *
+	 * // another thread using the same deferredObject
+	 * deferredObject.cancel();
+	 *
+	 * </code>
+	 * </pre>
+	 *
+	 * @return
+	 */
+	Deferred<D, F, P> cancel();
+
+	void setTask(DeferredFutureTask<D, P> task);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/Deferred.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/Deferred.java
@@ -17,8 +17,6 @@ package org.jdeferred;
 
 import org.jdeferred.impl.DeferredObject;
 
-import java.util.concurrent.FutureTask;
-
 /**
  * Deferred interface to trigger an event (resolve, reject, notify).
  * Subsequently, this will allow Promise observers to listen in on the event
@@ -138,6 +136,4 @@ public interface Deferred<D, F, P> extends Promise<D, F, P> {
 	 * @return
 	 */
 	Deferred<D, F, P> cancel();
-
-	void setTask(DeferredFutureTask<D, P> task);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredCallable.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredCallable.java
@@ -31,7 +31,7 @@ import org.jdeferred.impl.DeferredObject;
  * @param <P> Type used for {@link Deferred#notify(Object)}
  */
 public abstract class DeferredCallable<D, P> implements Callable<D> {
-	private final Deferred<D, Throwable, P> deferred = new DeferredObject<D, Throwable, P>();
+	private final Deferred<D, Throwable, P> deferred = new DeferredObject<D, Throwable, P>(new DeferredFutureTask<D, P>(this));
 	private final StartPolicy startPolicy;
 	
 	public DeferredCallable() {

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredCallable.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredCallable.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredCallable.java
@@ -15,10 +15,10 @@
  */
 package org.jdeferred;
 
-import java.util.concurrent.Callable;
-
 import org.jdeferred.DeferredManager.StartPolicy;
 import org.jdeferred.impl.DeferredObject;
+
+import java.util.concurrent.Callable;
 
 /**
  * Use this as superclass in case you need to be able to return a result and notify progress.
@@ -31,7 +31,7 @@ import org.jdeferred.impl.DeferredObject;
  * @param <P> Type used for {@link Deferred#notify(Object)}
  */
 public abstract class DeferredCallable<D, P> implements Callable<D> {
-	private final Deferred<D, Throwable, P> deferred = new DeferredObject<D, Throwable, P>(new DeferredFutureTask<D, P>(this));
+	private final Deferred<D, Throwable, P> deferred = new DeferredObject<D, Throwable, P>();
 	private final StartPolicy startPolicy;
 	
 	public DeferredCallable() {

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredFutureTask.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredFutureTask.java
@@ -15,13 +15,13 @@
  */
 package org.jdeferred;
 
+import org.jdeferred.DeferredManager.StartPolicy;
+import org.jdeferred.impl.DeferredObject;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
-
-import org.jdeferred.DeferredManager.StartPolicy;
-import org.jdeferred.impl.DeferredObject;
 
 /**
  * FutureTask can wrap around {@link Callable} and {@link Runnable}.
@@ -46,13 +46,13 @@ public class DeferredFutureTask<D, P> extends FutureTask<D> {
 	
 	public DeferredFutureTask(Callable<D> callable) {
 		super(callable);
-		this.deferred = new DeferredObject<D, Throwable, P>(this);
+		this.deferred = new DeferredObject<D, Throwable, P>();
 		this.startPolicy = StartPolicy.DEFAULT;
 	}
 	
 	public DeferredFutureTask(Runnable runnable) {
 		super(runnable, null);
-		this.deferred = new DeferredObject<D, Throwable, P>(this);
+		this.deferred = new DeferredObject<D, Throwable, P>();
 		this.startPolicy = StartPolicy.DEFAULT;
 	}
 	

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredFutureTask.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredFutureTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredFutureTask.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredFutureTask.java
@@ -46,13 +46,13 @@ public class DeferredFutureTask<D, P> extends FutureTask<D> {
 	
 	public DeferredFutureTask(Callable<D> callable) {
 		super(callable);
-		this.deferred = new DeferredObject<D, Throwable, P>();
+		this.deferred = new DeferredObject<D, Throwable, P>(this);
 		this.startPolicy = StartPolicy.DEFAULT;
 	}
 	
 	public DeferredFutureTask(Runnable runnable) {
 		super(runnable, null);
-		this.deferred = new DeferredObject<D, Throwable, P>();
+		this.deferred = new DeferredObject<D, Throwable, P>(this);
 		this.startPolicy = StartPolicy.DEFAULT;
 	}
 	
@@ -77,7 +77,7 @@ public class DeferredFutureTask<D, P> extends FutureTask<D> {
 	protected void done() {
 		try {
 			if (isCancelled()) {
-				deferred.reject(new CancellationException());
+				deferred.cancel();
 				return;
 			}
 			D result = get();

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredRunnable.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DoneCallback.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DoneCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DoneFilter.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DoneFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DonePipe.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DonePipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailCallback.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailFilter.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailPipe.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/FailPipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressCallback.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressFilter.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressPipe.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/ProgressPipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
@@ -15,6 +15,8 @@
  */
 package org.jdeferred;
 
+import org.jdeferred.impl.FilteredPromise;
+
 /**
  * Promise interface to observe when some action has occurred on the corresponding {@link Deferred} object.
  * 
@@ -72,7 +74,12 @@ public interface Promise<D, F, P> {
 		 * 
 		 * @see Deferred#resolve(Object)
 		 */
-		RESOLVED
+		RESOLVED,
+
+		/**
+		 * The Promise was cancelled
+		 */
+		CANCELLED
 	}
 
 	public State state();
@@ -94,6 +101,12 @@ public interface Promise<D, F, P> {
 	 * @return
 	 */
 	public boolean isRejected();
+
+	/**
+	 * @see State#CANCELLED
+	 * @return
+	 */
+	public boolean isCancelled();
 
 	/**
 	 * Equivalent to {@link #done(DoneCallback)}
@@ -165,10 +178,10 @@ public interface Promise<D, F, P> {
 	 * deferred.resolve(1); // prints 10
 	 * </code>
 	 * </pre>
-	 * 
-	 * @param doneFilter if null, use {@link NoOpDoneFilter}
-	 * @param failFilter if null, use {@link NoOpFailFilter}
-	 * @param progressFilter if null, use {@link NoOpProgressFilter}
+	 *
+	 * @param doneFilter if null, use {@link FilteredPromise.NoOpDoneFilter}
+	 * @param failFilter if null, use {@link FilteredPromise.NoOpFailFilter}
+	 * @param progressFilter if null, use {@link FilteredPromise.NoOpProgressFilter}
 	 * @return
 	 */
 	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
@@ -338,5 +351,27 @@ public interface Promise<D, F, P> {
 	 * @throws InterruptedException
 	 */
 	public void waitSafely(long timeout) throws InterruptedException;
-	
+
+	/**
+	 * This method will register {@link CancelCallback} so that when a Deferred object
+	 * is cancelled ({@link Deferred#cancel()}), {@link CancelCallback} will be triggered.
+	 *
+	 * You can register multiple {@link CancelCallback} by calling the method multiple times.
+	 * The order of callback trigger is based on the order you call this method.
+	 *
+	 * <pre>
+	 * <code>
+	 * promise.cancel(new CancelCallback(){
+	 * 	 public void onCancel() {
+	 *     ...
+	 *   }
+	 * });
+	 * </code>
+	 * </pre>
+	 *
+	 * @see Deferred#cancel()
+	 * @param callback
+	 * @return
+	 */
+	public Promise<D, F, P> cancel(CancelCallback callback);
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractMasterDeferredObject.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractMasterDeferredObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractMasterDeferredObject.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractMasterDeferredObject.java
@@ -15,6 +15,7 @@
  */
 package org.jdeferred.impl;
 
+import org.jdeferred.CancelCallback;
 import org.jdeferred.DoneCallback;
 import org.jdeferred.FailCallback;
 import org.jdeferred.ProgressCallback;
@@ -35,6 +36,7 @@ class AbstractMasterDeferredObject extends DeferredObject<MultipleResults, OneRe
 	private final int numberOfPromises;
 	private final AtomicInteger doneCount = new AtomicInteger();
 	private final AtomicInteger failCount = new AtomicInteger();
+	private final AtomicInteger cancelCount = new AtomicInteger();
 
 	AbstractMasterDeferredObject(MutableMultipleResults results) {
 		this.results = results;
@@ -48,10 +50,10 @@ class AbstractMasterDeferredObject extends DeferredObject<MultipleResults, OneRe
 					if (!AbstractMasterDeferredObject.this.isPending())
 						return;
 
-					final int fail = failCount.incrementAndGet();
 					AbstractMasterDeferredObject.this.notify(new MasterProgress(
 						doneCount.get(),
-						fail,
+						failCount.incrementAndGet(),
+						cancelCount.get(),
 						numberOfPromises));
 
 					AbstractMasterDeferredObject.this.reject(new OneReject<F>(index, promise, result));
@@ -66,6 +68,7 @@ class AbstractMasterDeferredObject extends DeferredObject<MultipleResults, OneRe
 					AbstractMasterDeferredObject.this.notify(new OneProgress<P>(
 						doneCount.get(),
 						failCount.get(),
+						cancelCount.get(),
 						numberOfPromises, index, promise, progress));
 				}
 			}
@@ -81,11 +84,28 @@ class AbstractMasterDeferredObject extends DeferredObject<MultipleResults, OneRe
 					AbstractMasterDeferredObject.this.notify(new MasterProgress(
 						done,
 						failCount.get(),
+						cancelCount.get(),
 						numberOfPromises));
 
 					if (done == numberOfPromises) {
 						AbstractMasterDeferredObject.this.resolve(results);
 					}
+				}
+			}
+		}).cancel(new CancelCallback() {
+			@Override
+			public void onCancel() {
+				synchronized (AbstractMasterDeferredObject.this) {
+					if (!AbstractMasterDeferredObject.this.isPending())
+						return;
+
+					AbstractMasterDeferredObject.this.notify(new MasterProgress(
+						doneCount.get(),
+						failCount.get(),
+						cancelCount.incrementAndGet(),
+						numberOfPromises));
+
+					AbstractMasterDeferredObject.this.cancel();
 				}
 			}
 		});

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractMultipleResults.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractMultipleResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractMutableMultipleResults.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractMutableMultipleResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
@@ -15,14 +15,8 @@
  */
 package org.jdeferred.impl;
 
-import java.util.List;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.FutureTask;
-
 import org.jdeferred.AlwaysCallback;
 import org.jdeferred.CancelCallback;
-import org.jdeferred.DeferredFutureTask;
 import org.jdeferred.DoneCallback;
 import org.jdeferred.DoneFilter;
 import org.jdeferred.DonePipe;
@@ -35,6 +29,10 @@ import org.jdeferred.ProgressPipe;
 import org.jdeferred.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  *
@@ -55,11 +53,6 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 
 	protected D resolveResult;
 	protected F rejectResult;
-	protected DeferredFutureTask<D, P> futureTask;
-
-	protected AbstractPromise(DeferredFutureTask<D, P> futureTask) {
-		this.futureTask = futureTask;
-	}
 
 	@Override
 	public State state() {
@@ -179,11 +172,6 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	}
 
 	protected void triggerCancel() {
-		try {
-			futureTask.cancel(true);
-		} catch(CancellationException expected) {
-			// ignore ?
-		}
 		for (CancelCallback callback : cancelCallbacks) {
 			try {
 				triggerCancel(callback);
@@ -192,7 +180,6 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 			}
 		}
 		doneCallbacks.clear();
-		futureTask = null;
 	}
 
 	protected void triggerCancel(CancelCallback callback) {

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
@@ -112,7 +112,7 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 			try {
 				triggerDone(callback, resolved);
 			} catch (Exception e) {
-				log.error("an uncaught exception occured in a DoneCallback", e);
+				log.error("an uncaught exception occurred in a DoneCallback", e);
 			}
 		}
 		doneCallbacks.clear();
@@ -124,20 +124,27 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	
 	protected void triggerFail(F rejected) {
 		if (rejected instanceof CancellationException) {
-			triggerCancel();
-			return;
+			this.state = State.CANCELLED;
+			if(!cancelCallbacks.isEmpty()) {
+				doTriggerCancel();
+				return;
+			}
 		}
 
+		doTriggerFail(rejected);
+	}
+
+	private void doTriggerFail(F rejected) {
 		for (FailCallback<F> callback : failCallbacks) {
 			try {
 				triggerFail(callback, rejected);
 			} catch (Exception e) {
-				log.error("an uncaught exception occured in a FailCallback", e);
+				log.error("an uncaught exception occurred in a FailCallback", e);
 			}
 		}
 		failCallbacks.clear();
 	}
-	
+
 	protected void triggerFail(FailCallback<F> callback, F rejected) {
 		callback.onFail(rejected);
 	}
@@ -147,7 +154,7 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 			try {
 				triggerProgress(callback, progress);
 			} catch (Exception e) {
-				log.error("an uncaught exception occured in a ProgressCallback", e);
+				log.error("an uncaught exception occurred in a ProgressCallback", e);
 			}
 		}
 	}
@@ -161,7 +168,7 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 			try {
 				triggerAlways(callback, state, resolve, reject);
 			} catch (Exception e) {
-				log.error("an uncaught exception occured in a AlwaysCallback", e);
+				log.error("an uncaught exception occurred in a AlwaysCallback", e);
 			}
 		}
 		alwaysCallbacks.clear();
@@ -172,11 +179,19 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	}
 
 	protected void triggerCancel() {
+		if (cancelCallbacks.isEmpty()) {
+			doTriggerFail(null);
+			return;
+		}
+		doTriggerCancel();
+	}
+
+	private void doTriggerCancel() {
 		for (CancelCallback callback : cancelCallbacks) {
 			try {
 				triggerCancel(callback);
 			} catch (Exception e) {
-				log.error("an uncaught exception occured in a CancelCallback", e);
+				log.error("an uncaught exception occurred in a CancelCallback", e);
 			}
 		}
 		doneCallbacks.clear();

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DefaultDeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DefaultDeferredManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DeferredObject.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DeferredObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DeferredObject.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DeferredObject.java
@@ -16,7 +16,6 @@
 package org.jdeferred.impl;
 
 import org.jdeferred.Deferred;
-import org.jdeferred.DeferredFutureTask;
 import org.jdeferred.DoneCallback;
 import org.jdeferred.FailCallback;
 import org.jdeferred.ProgressCallback;
@@ -57,14 +56,6 @@ import org.jdeferred.Promise;
  * @author Ray Tsang
  */
 public class DeferredObject<D, F, P> extends AbstractPromise<D, F, P> implements Deferred<D, F, P> {
-
-	public DeferredObject() {
-		this(null);
-	}
-
-	public DeferredObject(DeferredFutureTask<D, P> task) {
-		super(task);
-	}
 
 	@Override
 	public Deferred<D, F, P> resolve(final D resolve) {
@@ -131,13 +122,5 @@ public class DeferredObject<D, F, P> extends AbstractPromise<D, F, P> implements
 			}
 		}
 		return this;
-	}
-
-	@Override
-	public void setTask(DeferredFutureTask<D, P> task) {
-		if (futureTask != null)
-			throw new IllegalStateException("Deferred object already has an assigned task");
-
-		futureTask = task;
 	}
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DeferredPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DeferredPromise.java
@@ -16,6 +16,7 @@
 package org.jdeferred.impl;
 
 import org.jdeferred.AlwaysCallback;
+import org.jdeferred.CancelCallback;
 import org.jdeferred.Deferred;
 import org.jdeferred.DoneCallback;
 import org.jdeferred.DoneFilter;
@@ -51,6 +52,10 @@ public class DeferredPromise<D, F, P> implements Promise<D, F, P> {
 
 	public boolean isRejected() {
 		return promise.isRejected();
+	}
+
+	public boolean isCancelled() {
+		return promise.isCancelled();
 	}
 
 	public Promise<D, F, P> then(DoneCallback<D> doneCallback) {
@@ -100,9 +105,13 @@ public class DeferredPromise<D, F, P> implements Promise<D, F, P> {
 	}
 
 	@Override
+	public Promise<D, F, P> cancel(CancelCallback callback) {
+		return promise.cancel(callback);
+	}
+
+	@Override
 	public void waitSafely() throws InterruptedException {
 		promise.waitSafely();
-		
 	}
 
 	@Override

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DeferredPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DeferredPromise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
@@ -16,6 +16,7 @@
 package org.jdeferred.impl;
 
 import org.jdeferred.AlwaysCallback;
+import org.jdeferred.CancelCallback;
 import org.jdeferred.DoneCallback;
 import org.jdeferred.DoneFilter;
 import org.jdeferred.DonePipe;
@@ -149,5 +150,15 @@ public abstract class DelegatingPromise<D, F, P> implements Promise<D, F, P> {
     @Override
     public void waitSafely(long timeout) throws InterruptedException {
         getDelegate().waitSafely(timeout);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return getDelegate().isCancelled();
+    }
+
+    @Override
+    public Promise<D, F, P> cancel(CancelCallback callback) {
+        return getDelegate().cancel(callback);
     }
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/FilteredPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/FilteredPromise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/FutureCallable.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/FutureCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject2.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject3.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject4.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject5.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObjectN.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObjectN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResults.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResults2.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResults2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResults3.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResults3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResults4.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResults4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResults5.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResults5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResultsN.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MutableMultipleResultsN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/PipedPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/PipedPromise.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MasterProgress.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MasterProgress.java
@@ -17,19 +17,21 @@ package org.jdeferred.multiple;
 
 /**
  * Progress indicating how many promises need to finish ({@link #total}),
- * and how many had already finish ({@link #fulfilled}).
+ * and how many had already finish ({@code fulfilled}).
  * @author Ray Tsang
  *
  */
 public class MasterProgress {
 	private final int done;
 	private final int fail;
+	private final int cancel;
 	private final int total;
 	
-	public MasterProgress(int done, int fail, int total) {
+	public MasterProgress(int done, int fail, int cancel, int total) {
 		super();
 		this.done = done;
 		this.fail = fail;
+		this.cancel = cancel;
 		this.total = total;
 	}
 
@@ -41,6 +43,10 @@ public class MasterProgress {
 		return fail;
 	}
 
+	public int getCancel() {
+		return cancel;
+	}
+
 	public int getTotal() {
 		return total;
 	}
@@ -48,6 +54,6 @@ public class MasterProgress {
 	@Override
 	public String toString() {
 		return "MasterProgress [done=" + done + ", fail=" + fail
-				+ ", total=" + total + "]";
+			+ ", cancel=" + cancel + ", total=" + total + "]";
 	}
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MasterProgress.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MasterProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResults.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResults2.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResults2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResults3.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResults3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResults4.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResults4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResults5.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResults5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResultsN.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/MultipleResultsN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneProgress.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneProgress.java
@@ -28,8 +28,8 @@ public class OneProgress<P> extends MasterProgress {
 	private final Promise<?, ?, P> promise;
 	private final P progress;
 
-	public OneProgress(int done, int fail, int total, int index, Promise<?, ?, P> promise, P progress) {
-		super(done, fail, total);
+	public OneProgress(int done, int fail, int total, int cancel, int index, Promise<?, ?, P> promise, P progress) {
+		super(done, fail, cancel, total);
 		this.index = index;
 		this.promise = promise;
 		this.progress = progress;
@@ -50,8 +50,9 @@ public class OneProgress<P> extends MasterProgress {
 	@Override
 	public String toString() {
 		return "OneProgress [index=" + index + ", promise=" + promise
-			+ ", progress=" + progress + ", getDone()=" + getDone()
-			+ ", getFail()=" + getFail() + ", getTotal()=" + getTotal()
-			+ "]";
+				+ ", progress=" + progress + ", getDone()=" + getDone()
+			    + ", getFail()=" + getFail() + ", getCancel()=" + getCancel()
+				+ ", getTotal()=" + getTotal()
+				+ "]";
 	}
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneProgress.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneProgress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneReject.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneReject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneResult.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/multiple/OneResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/AbstractDeferredTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/AbstractDeferredTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
@@ -25,7 +25,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
@@ -35,56 +34,6 @@ import static org.junit.Assert.assertTrue;
 public class CancelTaskTest extends AbstractDeferredTest {
 	@Test
 	public void testCancelTask() {
-		final AtomicBoolean cancelWitness = new AtomicBoolean(false);
-
-		DeferredFutureTask<String, Void> deferredFutureTask =
-				new DeferredFutureTask<String, Void>(new Callable<String>() {
-					@Override
-					public String call() throws Exception {
-						try {
-							Thread.sleep(1000);
-						} catch (InterruptedException e) {
-						}
-
-						return "Hello";
-					}
-				});
-
-		Promise<String, Throwable, Void> promise = deferredManager.when(deferredFutureTask);
-
-		promise.then(new DoneCallback<String>() {
-			@Override
-			public void onDone(String result) {
-				Assert.fail("Shouldn't be called, because task was cancelled");
-			}
-		}).always(new AlwaysCallback<String, Throwable>() {
-			@Override
-			public void onAlways(State state, String resolved, Throwable rejected) {
-				assertEquals(State.CANCELLED, state);
-				assertNull(resolved);
-				assertNull(rejected);
-			}
-		}).cancel(new CancelCallback() {
-			@Override
-			public void onCancel() {
-				cancelWitness.set(true);
-			}
-		});
-
-		deferredFutureTask.cancel(false);
-
-		try {
-			Thread.sleep(1000);
-		} catch (InterruptedException e) {
-		}
-
-		assertTrue(deferredFutureTask.isCancelled());
-		assertTrue(promise.isCancelled());
-		assertTrue(cancelWitness.get());
-	}
-
-	@Test
-	public void testCancelPromiseDirectly() {
 		final AtomicBoolean cancelWitness = new AtomicBoolean(false);
 
 		DeferredFutureTask<String, Void> deferredFutureTask =

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
@@ -1,5 +1,5 @@
-/*                                                                                            
- * Copyright 2013-2016 Ray Tsang
+/*
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/FailureTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/FailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/FilteredPromiseTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/FilteredPromiseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/MultiplePromisesTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/MultiplePromisesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/PipedPromiseTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/PipedPromiseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/SinglePromiseTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/SinglePromiseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/ValueHolder.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/ValueHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 Ray Tsang
+ * Copyright 2013-2017 Ray Tsang
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds initial support for receiving task cancellation notice to a Promise.
Does not provide a mechanism for the cancelled task to cleanup resources; this will come later on another PR. Adapted from #98

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jdeferred/jdeferred/123)
<!-- Reviewable:end -->
