### PR TITLE
Cancellation handler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ buildscript {
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.1'
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
-        classpath 'net.nemerosa:versioning:2.6.1'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.14.0'
+        classpath 'net.nemerosa:versioning:2.6.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,5 @@ androidVersion    = 4.1.1.4
 awaitilityVersion = 3.0.0
 jacocoVersion     = 0.7.9
 junitVersion      = 4.12
+JUnitParamsVersion = 1.1.0
 slf4jVersion      = 1.7.25

--- a/subprojects/jdeferred-core/jdeferred-core.gradle
+++ b/subprojects/jdeferred-core/jdeferred-core.gradle
@@ -28,6 +28,8 @@ dependencies {
     compile "org.slf4j:slf4j-api:$slf4jVersion"
     testCompile "junit:junit:$junitVersion"
     testCompile "org.slf4j:slf4j-jdk14:$slf4jVersion"
+    testCompile "org.awaitility:awaitility:$awaitilityVersion"
+    testCompile "pl.pragmatists:JUnitParams:$JUnitParamsVersion"
 }
 
 task sourcesJar(type: Jar) {

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/CancellationHandler.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/CancellationHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2017 Ray Tsang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jdeferred;
+
+/**
+ * Allows a {@code DeferredFutureTask} to onCancel resources when its task is interrupted or cancelled.
+ *
+ * @author Ray Tsang
+ * @author Andres Almiray
+ * @author Stephan Classen
+ */
+public interface CancellationHandler {
+	/**
+	 * Invoked when the owning task is interrupted or cancelled.
+	 */
+	void onCancel();
+}

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredFutureTask.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredFutureTask.java
@@ -178,7 +178,6 @@ public class DeferredFutureTask<D, P> extends FutureTask<D> {
 				cleanup();
 			}
 		} catch (Throwable t) {
-			t.printStackTrace();
 			// TODO: forward to global ExceptionHandler
 			LOG.warn("Unexpected error when resolving value", t);
 		}
@@ -201,7 +200,6 @@ public class DeferredFutureTask<D, P> extends FutureTask<D> {
 				((CancellationHandler) taskDelegate).onCancel();
 			}
 		} catch (Throwable t) {
-			t.printStackTrace();
 			// TODO: forward to global ExceptionHandler
 			LOG.warn("Unexpected error when cleaning up", t);
 		}

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
@@ -78,7 +78,7 @@ public class CancelTaskTest extends AbstractDeferredTest {
 	public void explicitRejectionWithCancellationException() {
 		final AtomicBoolean failWitness = new AtomicBoolean(false);
 
-		DeferredObject<String, Throwable, Void> deferredObject = new DeferredObject<>();
+		DeferredObject<String, Throwable, Void> deferredObject = new DeferredObject<String, Throwable, Void>();
 
 		Promise<String, Throwable, Void> promise = deferredObject.promise()
 			.then(new DoneCallback<String>() {

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/CancelTaskTest.java
@@ -15,55 +15,267 @@
  */
 package org.jdeferred.impl;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.jdeferred.AlwaysCallback;
+import org.jdeferred.CancellationHandler;
+import org.jdeferred.DeferredCallable;
 import org.jdeferred.DeferredFutureTask;
+import org.jdeferred.DeferredRunnable;
 import org.jdeferred.DoneCallback;
+import org.jdeferred.FailCallback;
 import org.jdeferred.Promise;
 import org.jdeferred.Promise.State;
-import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(JUnitParamsRunner.class)
 public class CancelTaskTest extends AbstractDeferredTest {
 	@Test
-	public void testCancelTask() {
-		DeferredFutureTask<String, Void> deferredFutureTask =
-				new DeferredFutureTask<String, Void>(new Callable<String>() {
-					@Override
-					public String call() throws Exception {
-						try {
-							Thread.sleep(1000);
-						} catch (InterruptedException e) {
-						}
+	@Parameters(method = "basicTasks")
+	public void cancelTask(DeferredFutureTask<String, Void> deferredFutureTask) {
+		final AtomicBoolean failWitness = new AtomicBoolean(false);
 
-						return "Hello";
-					}
-				});
+		Promise<String, Throwable, Void> promise = deferredManager.when(deferredFutureTask)
+			.then(new DoneCallback<String>() {
+				@Override
+				public void onDone(String result) {
+					fail("Shouldn't be called, because task was cancelled");
+				}
+			}).always(new AlwaysCallback<String, Throwable>() {
+				@Override
+				public void onAlways(State state, String resolved, Throwable rejected) {
+					assertEquals(State.REJECTED, state);
+					assertNull(resolved);
+					assertTrue(rejected instanceof CancellationException);
+				}
+			}).fail(new FailCallback<Throwable>() {
+				@Override
+				public void onFail(Throwable result) {
+					failWitness.set(true);
+				}
+			});
+
+		deferredFutureTask.cancel(true);
+
+		assertTrue(promise.isRejected());
+		assertTrue(failWitness.get());
+	}
+
+	@Test
+	public void explicitRejectionWithCancellationException() {
+		final AtomicBoolean failWitness = new AtomicBoolean(false);
+
+		DeferredObject<String, Throwable, Void> deferredObject = new DeferredObject<>();
+
+		Promise<String, Throwable, Void> promise = deferredObject.promise()
+			.then(new DoneCallback<String>() {
+				@Override
+				public void onDone(String result) {
+					fail("Shouldn't be called, because task was cancelled");
+				}
+			}).always(new AlwaysCallback<String, Throwable>() {
+				@Override
+				public void onAlways(State state, String resolved, Throwable rejected) {
+					assertEquals(State.REJECTED, state);
+					assertNull(resolved);
+					assertTrue(rejected instanceof CancellationException);
+				}
+			}).fail(new FailCallback<Throwable>() {
+				@Override
+				public void onFail(Throwable result) {
+					failWitness.set(true);
+				}
+			});
+		deferredObject.reject(new CancellationException());
+
+		assertTrue(promise.isRejected());
+		assertTrue(failWitness.get());
+	}
+
+	@Test
+	@Parameters(method = "tasksAsCancellationHandler")
+	public void tasksImplementCancellationHandler(CancellationWitness cancellationWitness) throws Exception {
+		DeferredFutureTask<String, Void> deferredFutureTask = createDeferredFutureTaskFromWitness(cancellationWitness);
 
 		Promise<String, Throwable, Void> promise = deferredManager.when(deferredFutureTask);
+		deferredFutureTask.cancel(true);
 
-		deferredFutureTask.cancel(false);
+		assertTrue(promise.isRejected());
+		assertTrue(cancellationWitness.invoked());
+	}
 
+	@Test
+	@Parameters(method = "tasksWithExplicitCancellationHandler")
+	public void taskswithExplicitCancellationHandler(CancellationWitness taskCancellationWitness, CancellationWitness cancellationWitness) throws Exception {
+		DeferredFutureTask<String, Void> deferredFutureTask = createDeferredFutureTaskFromWitness(taskCancellationWitness, cancellationWitness);
+
+		Promise<String, Throwable, Void> promise = deferredManager.when(deferredFutureTask);
+		deferredFutureTask.cancel(true);
+
+		assertTrue(promise.isRejected());
+		assertFalse(taskCancellationWitness.invoked());
+		assertTrue(cancellationWitness.invoked());
+	}
+
+	@SuppressWarnings("unchecked")
+	private DeferredFutureTask<String, Void> createDeferredFutureTaskFromWitness(CancellationWitness cancellationWitness) {
+		return createDeferredFutureTaskFromWitness(cancellationWitness, null);
+	}
+
+	@SuppressWarnings("unchecked")
+	private DeferredFutureTask<String, Void> createDeferredFutureTaskFromWitness(CancellationWitness cancellationWitness, CancellationHandler cancellationHandler) {
+		if (cancellationWitness instanceof DeferredRunnable) {
+			return new DeferredFutureTask<String, Void>((DeferredRunnable<Void>) cancellationWitness, cancellationHandler);
+		} else if (cancellationWitness instanceof DeferredCallable) {
+			return new DeferredFutureTask<String, Void>((DeferredCallable<String, Void>) cancellationWitness, cancellationHandler);
+		} else if (cancellationWitness instanceof Runnable) {
+			return new DeferredFutureTask<String, Void>((Runnable) cancellationWitness, cancellationHandler);
+		} else if (cancellationWitness instanceof Callable) {
+			return new DeferredFutureTask<String, Void>((Callable<String>) cancellationWitness, cancellationHandler);
+		}
+		fail("invalid witness argument " + cancellationWitness.getClass());
+		return null; // shakes fist at JUnit API because fail() neither declares a throws clause nor returns a Throwable
+	}
+
+	private DeferredFutureTask[] basicTasks() {
+		return new DeferredFutureTask[]{
+			new DeferredFutureTask<String, Void>(new Callable<String>() {
+				@Override
+				public String call() throws Exception {
+					simulateWork();
+					return "Hello";
+				}
+			}),
+			new DeferredFutureTask<String, Void>(new Runnable() {
+				@Override
+				public void run() {
+					simulateWork();
+				}
+			}),
+			new DeferredFutureTask<String, Void>(new DeferredCallable<String, Void>() {
+				@Override
+				public String call() throws Exception {
+					simulateWork();
+					return "Hello";
+				}
+			}),
+			new DeferredFutureTask<String, Void>(new DeferredRunnable<Void>() {
+				@Override
+				public void run() {
+					simulateWork();
+				}
+			})
+		};
+	}
+
+	private CancellationWitness[] tasksAsCancellationHandler() {
+		return new CancellationWitness[]{
+			new CancellationHandlerCallable(),
+			new CancellationHandlerRunnable(),
+			new CancellationHandlerDeferredCallable(),
+			new CancellationHandlerDeferredRunnable()
+		};
+	}
+
+	private CancellationWitness[][] tasksWithExplicitCancellationHandler() {
+		return new CancellationWitness[][]{
+			new CancellationWitness[]{new CancellationHandlerCallable(), new DefaultCancellationHandler()},
+			new CancellationWitness[]{new CancellationHandlerRunnable(), new DefaultCancellationHandler()},
+			new CancellationWitness[]{new CancellationHandlerDeferredCallable(), new DefaultCancellationHandler()},
+			new CancellationWitness[]{new CancellationHandlerDeferredRunnable(), new DefaultCancellationHandler()}
+		};
+	}
+
+	private static void simulateWork() {
+		CountDownLatch latch = new CountDownLatch(1);
 		try {
-			Thread.sleep(1000);
+			latch.await(5, TimeUnit.SECONDS);
 		} catch (InterruptedException e) {
 		}
+	}
 
-		promise.then(new DoneCallback<String>() {
-			@Override
-			public void onDone(String result) {
-				Assert.fail("Shouldn't be called, because task was cancelled");
-			}
-		}).always(new AlwaysCallback<String, Throwable>() {
-			@Override
-			public void onAlways(State state, String resolved, Throwable rejected) {
-				Assert.assertEquals(State.REJECTED, state);
-				Assert.assertTrue(rejected instanceof CancellationException);
-			}
-		});
+	public interface CancellationWitness extends CancellationHandler {
+		boolean invoked();
+	}
 
-		Assert.assertTrue(deferredFutureTask.isCancelled());
+	public static class DefaultCancellationHandler implements CancellationWitness {
+		private volatile boolean invoked;
+
+		@Override
+		public void onCancel() {
+			invoked = true;
+		}
+
+		@Override
+		public boolean invoked() {
+			return invoked;
+		}
+	}
+
+	public static class CancellationHandlerCallable extends DefaultCancellationHandler implements Callable<String> {
+		@Override
+		public String call() throws Exception {
+			simulateWork();
+			return "Hello";
+		}
+	}
+
+	public static class CancellationHandlerRunnable extends DefaultCancellationHandler implements Runnable {
+		@Override
+		public void run() {
+			simulateWork();
+		}
+	}
+
+	public static class CancellationHandlerDeferredCallable extends DeferredCallable<String, Void> implements CancellationWitness {
+		private volatile boolean invoked;
+
+		@Override
+		public String call() throws Exception {
+			simulateWork();
+			return "Hello";
+		}
+
+		@Override
+		public void onCancel() {
+			invoked = true;
+		}
+
+		@Override
+		public boolean invoked() {
+			return invoked;
+		}
+	}
+
+	public static class CancellationHandlerDeferredRunnable extends DeferredRunnable<Void> implements CancellationWitness {
+		private volatile boolean invoked;
+
+		@Override
+		public void run() {
+			simulateWork();
+		}
+
+		@Override
+		public void onCancel() {
+			invoked = true;
+		}
+
+		@Override
+		public boolean invoked() {
+			return invoked;
+		}
 	}
 }


### PR DESCRIPTION
As discussed during BaselOne, `DeferredFutureTask` is now able to cleanup any resources when the underlying task is interrupted or cancelled.
Tests were parameterized with JUnitParams,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jdeferred/jdeferred/126)
<!-- Reviewable:end -->
