### PR TITLE
Allow CallbackExceptionHandler to be set on DeferredManager and Promise

### DIFF
--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/impl/DefaultAndroidDeferredManager.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/impl/DefaultAndroidDeferredManager.java
@@ -3,6 +3,7 @@ package org.jdeferred.impl;
 import android.annotation.SuppressLint;
 import android.os.AsyncTask;
 import android.os.Build;
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.DeferredFutureTask;
 import org.jdeferred.DeferredManager;
 import org.jdeferred.Promise;
@@ -55,7 +56,7 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		DeferredAsyncTask<Void, ?, V2> taskV2) {
 		assertNotNull(taskV1, TASK_V1);
 		assertNotNull(taskV2, TASK_V2);
-		return new MasterDeferredObject2(when(taskV1), when(taskV2));
+		return new MasterDeferredObject2(callbackExceptionHandler, when(taskV1), when(taskV2));
 	}
 
 	public <V1, V2, V3> Promise<MultipleResults3, OneReject<?>, MasterProgress> when(
@@ -65,7 +66,7 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		assertNotNull(taskV1, TASK_V1);
 		assertNotNull(taskV2, TASK_V2);
 		assertNotNull(taskV3, TASK_V3);
-		return new MasterDeferredObject3(when(taskV1), when(taskV2), when(taskV3));
+		return new MasterDeferredObject3(callbackExceptionHandler, when(taskV1), when(taskV2), when(taskV3));
 	}
 
 	public <V1, V2, V3, V4> Promise<MultipleResults4, OneReject<?>, MasterProgress> when(
@@ -77,7 +78,7 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		assertNotNull(taskV2, TASK_V2);
 		assertNotNull(taskV3, TASK_V3);
 		assertNotNull(taskV4, TASK_V4);
-		return new MasterDeferredObject4(when(taskV1), when(taskV2), when(taskV3), when(taskV4));
+		return new MasterDeferredObject4(callbackExceptionHandler, when(taskV1), when(taskV2), when(taskV3), when(taskV4));
 	}
 
 	public <V1, V2, V3, V4, V5> Promise<MultipleResults5, OneReject<?>, MasterProgress> when(
@@ -91,7 +92,7 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		assertNotNull(taskV3, TASK_V3);
 		assertNotNull(taskV4, TASK_V4);
 		assertNotNull(taskV5, TASK_V5);
-		return new MasterDeferredObject5(when(taskV1), when(taskV2), when(taskV3), when(taskV4), when(taskV5));
+		return new MasterDeferredObject5(callbackExceptionHandler, when(taskV1), when(taskV2), when(taskV3), when(taskV4), when(taskV5));
 	}
 
 	public <V1, V2, V3, V4, V5> Promise<MultipleResultsN, OneReject<?>, MasterProgress> when(
@@ -120,7 +121,7 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		for (int i = 0; i < tasks.length; i++) {
 			promiseN[i] = when(tasks[i]);
 		}
-		return new MasterDeferredObjectN(promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
+		return new MasterDeferredObjectN(callbackExceptionHandler, promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
 	}
 
 	public <V1, V2> Promise<MultipleResults2, OneReject<?>, MasterProgress> when(
@@ -129,7 +130,7 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		DeferredAsyncTask<Void, ?, V2> taskV2) {
 		assertNotNull(taskV1, TASK_V1);
 		assertNotNull(taskV2, TASK_V2);
-		return new MasterDeferredObject2(when(taskV1, scope), when(taskV2, scope));
+		return new MasterDeferredObject2(callbackExceptionHandler, when(taskV1, scope), when(taskV2, scope));
 	}
 
 	public <V1, V2, V3> Promise<MultipleResults3, OneReject<?>, MasterProgress> when(
@@ -140,7 +141,7 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		assertNotNull(taskV1, TASK_V1);
 		assertNotNull(taskV2, TASK_V2);
 		assertNotNull(taskV3, TASK_V3);
-		return new MasterDeferredObject3(when(taskV1, scope), when(taskV2, scope), when(taskV3, scope));
+		return new MasterDeferredObject3(callbackExceptionHandler, when(taskV1, scope), when(taskV2, scope), when(taskV3, scope));
 	}
 
 	public <V1, V2, V3, V4> Promise<MultipleResults4, OneReject<?>, MasterProgress> when(
@@ -153,7 +154,7 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		assertNotNull(taskV2, TASK_V2);
 		assertNotNull(taskV3, TASK_V3);
 		assertNotNull(taskV4, TASK_V4);
-		return new MasterDeferredObject4(when(taskV1, scope), when(taskV2, scope), when(taskV3, scope), when(taskV4, scope));
+		return new MasterDeferredObject4(callbackExceptionHandler, when(taskV1, scope), when(taskV2, scope), when(taskV3, scope), when(taskV4, scope));
 	}
 
 	public <V1, V2, V3, V4, V5> Promise<MultipleResults5, OneReject<?>, MasterProgress> when(
@@ -168,7 +169,7 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		assertNotNull(taskV3, TASK_V3);
 		assertNotNull(taskV4, TASK_V4);
 		assertNotNull(taskV5, TASK_V5);
-		return new MasterDeferredObject5(when(taskV1, scope), when(taskV2, scope), when(taskV3, scope), when(taskV4, scope), when(taskV5, scope));
+		return new MasterDeferredObject5(callbackExceptionHandler, when(taskV1, scope), when(taskV2, scope), when(taskV3, scope), when(taskV4, scope), when(taskV5, scope));
 	}
 
 	public <V1, V2, V3, V4, V5> Promise<MultipleResultsN, OneReject<?>, MasterProgress> when(
@@ -198,7 +199,7 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		for (int i = 0; i < tasks.length; i++) {
 			promiseN[i] = when(tasks[i], scope);
 		}
-		return new MasterDeferredObjectN(promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
+		return new MasterDeferredObjectN(callbackExceptionHandler, promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
 	}
 
 	/**
@@ -238,12 +239,14 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 			}
 		}
 
-		return task.promise();
+		Promise<Result, Throwable, Progress> promise = task.promise();
+		promise.setCallbackExceptionHandler(callbackExceptionHandler);
+		return promise;
 	}
 
 	public <Progress, Result> Promise<Result, Throwable, Progress> when(
 		DeferredAsyncTask<Void, Progress, Result> task, AndroidExecutionScope scope) {
-		return when(when(task.promise()), scope);
+		return when(task.promise(), scope);
 	}
 
 	/**
@@ -251,7 +254,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 	 */
 	@Override
 	public <D, P> Promise<D, Throwable, P> when(DeferredFutureTask<D, P> task) {
-		return new AndroidDeferredObject<D, Throwable, P>(super.when(task)).promise();
+		AndroidDeferredObject<D, Throwable, P> deferredObject = new AndroidDeferredObject<D, Throwable, P>(super.when(task));
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<D, Throwable, P>) deferredObject).promise();
 	}
 
 	/**
@@ -263,7 +268,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		if (promise instanceof AndroidDeferredObject) {
 			return promise;
 		}
-		return new AndroidDeferredObject<D, F, P>(promise).promise();
+		AndroidDeferredObject<D, F, P> deferredObject = new AndroidDeferredObject<D, F, P>(promise);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<D, F, P>) deferredObject).promise();
 	}
 
 	/**
@@ -279,7 +286,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 		if (promise instanceof AndroidDeferredObject) {
 			return promise;
 		}
-		return new AndroidDeferredObject<D, F, P>(promise, scope).promise();
+		AndroidDeferredObject<D, F, P> deferredObject = new AndroidDeferredObject<D, F, P>(promise, scope);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<D, F, P>) deferredObject).promise();
 	}
 
 	/**
@@ -289,7 +298,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 	@Override
 	public <R, V1, V2> Promise<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress> when(Promise<V1, ?, ?> promiseV1, Promise<V2, ?, ?> promiseV2) {
 		Promise<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress> p = super.when(promiseV1, promiseV2);
-		return new AndroidDeferredObject<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress>(p).promise();
+		AndroidDeferredObject<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress> deferredObject = new AndroidDeferredObject<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress>(p);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress>) deferredObject).promise();
 	}
 
 	/**
@@ -299,7 +310,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 	@Override
 	public <R, V1, V2, V3> Promise<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress> when(Promise<V1, ?, ?> promiseV1, Promise<V2, ?, ?> promiseV2, Promise<V3, ?, ?> promiseV3) {
 		Promise<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress> p = super.when(promiseV1, promiseV2, promiseV3);
-		return new AndroidDeferredObject<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress>(p).promise();
+		AndroidDeferredObject<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress> deferredObject = new AndroidDeferredObject<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress>(p);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress>) deferredObject).promise();
 	}
 
 	/**
@@ -309,7 +322,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 	@Override
 	public <R, V1, V2, V3, V4> Promise<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress> when(Promise<V1, ?, ?> promiseV1, Promise<V2, ?, ?> promiseV2, Promise<V3, ?, ?> promiseV3, Promise<V4, ?, ?> promiseV4) {
 		Promise<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress> p = super.when(promiseV1, promiseV2, promiseV3, promiseV4);
-		return new AndroidDeferredObject<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress>(p).promise();
+		AndroidDeferredObject<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress> deferredObject = new AndroidDeferredObject<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress>(p);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress>) deferredObject).promise();
 	}
 
 	/**
@@ -319,7 +334,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 	@Override
 	public <R, V1, V2, V3, V4, V5> Promise<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> when(Promise<V1, ?, ?> promiseV1, Promise<V2, ?, ?> promiseV2, Promise<V3, ?, ?> promiseV3, Promise<V4, ?, ?> promiseV4, Promise<V5, ?, ?> promiseV5) {
 		Promise<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> p = super.when(promiseV1, promiseV2, promiseV3, promiseV4, promiseV5);
-		return new AndroidDeferredObject<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>(p).promise();
+		AndroidDeferredObject<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> deferredObject = new AndroidDeferredObject<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>(p);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>) deferredObject).promise();
 	}
 
 	/**
@@ -329,7 +346,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 	@Override
 	public <R, V1, V2, V3, V4, V5> Promise<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> when(Promise<V1, ?, ?> promiseV1, Promise<V2, ?, ?> promiseV2, Promise<V3, ?, ?> promiseV3, Promise<V4, ?, ?> promiseV4, Promise<V5, ?, ?> promiseV5, Promise<?, ?, ?> promise6, Promise<?, ?, ?>... promises) {
 		Promise<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> p = super.when(promiseV1, promiseV2, promiseV3, promiseV4, promiseV5, promise6, promises);
-		return new AndroidDeferredObject<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>(p).promise();
+		AndroidDeferredObject<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> deferredObject = new AndroidDeferredObject<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>(p);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>) deferredObject).promise();
 	}
 
 	/**
@@ -340,7 +359,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 	 */
 	public <R, V1, V2> Promise<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress> when(AndroidExecutionScope scope, Promise<V1, ?, ?> promiseV1, Promise<V2, ?, ?> promiseV2) {
 		Promise<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress> p = super.when(promiseV1, promiseV2);
-		return new AndroidDeferredObject<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress>(p, scope).promise();
+		AndroidDeferredObject<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress> deferredObject = new AndroidDeferredObject<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress>(p, scope);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<MultipleResults2<V1, V2>, OneReject<R>, MasterProgress>) deferredObject).promise();
 	}
 
 	/**
@@ -351,7 +372,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 	 */
 	public <R, V1, V2, V3> Promise<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress> when(AndroidExecutionScope scope, Promise<V1, ?, ?> promiseV1, Promise<V2, ?, ?> promiseV2, Promise<V3, ?, ?> promiseV3) {
 		Promise<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress> p = super.when(promiseV1, promiseV2, promiseV3);
-		return new AndroidDeferredObject<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress>(p, scope).promise();
+		AndroidDeferredObject<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress> deferredObject = new AndroidDeferredObject<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress>(p, scope);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<MultipleResults3<V1, V2, V3>, OneReject<R>, MasterProgress>) deferredObject).promise();
 	}
 
 	/**
@@ -362,7 +385,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 	 */
 	public <R, V1, V2, V3, V4> Promise<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress> when(AndroidExecutionScope scope, Promise<V1, ?, ?> promiseV1, Promise<V2, ?, ?> promiseV2, Promise<V3, ?, ?> promiseV3, Promise<V4, ?, ?> promiseV4) {
 		Promise<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress> p = super.when(promiseV1, promiseV2, promiseV3, promiseV4);
-		return new AndroidDeferredObject<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress>(p, scope).promise();
+		AndroidDeferredObject<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress> deferredObject = new AndroidDeferredObject<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress>(p, scope);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<MultipleResults4<V1, V2, V3, V4>, OneReject<R>, MasterProgress>) deferredObject).promise();
 	}
 
 	/**
@@ -373,7 +398,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 	 */
 	public <R, V1, V2, V3, V4, V5> Promise<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> when(AndroidExecutionScope scope, Promise<V1, ?, ?> promiseV1, Promise<V2, ?, ?> promiseV2, Promise<V3, ?, ?> promiseV3, Promise<V4, ?, ?> promiseV4, Promise<V5, ?, ?> promiseV5) {
 		Promise<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> p = super.when(promiseV1, promiseV2, promiseV3, promiseV4, promiseV5);
-		return new AndroidDeferredObject<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>(p, scope).promise();
+		AndroidDeferredObject<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> deferredObject = new AndroidDeferredObject<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>(p, scope);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<MultipleResults5<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>) deferredObject).promise();
 	}
 
 	/**
@@ -384,7 +411,9 @@ public abstract class DefaultAndroidDeferredManager extends DefaultDeferredManag
 	 */
 	public <R, V1, V2, V3, V4, V5> Promise<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> when(AndroidExecutionScope scope, Promise<V1, ?, ?> promiseV1, Promise<V2, ?, ?> promiseV2, Promise<V3, ?, ?> promiseV3, Promise<V4, ?, ?> promiseV4, Promise<V5, ?, ?> promiseV5, Promise<?, ?, ?> promise6, Promise<?, ?, ?>... promises) {
 		Promise<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> p = super.when(promiseV1, promiseV2, promiseV3, promiseV4, promiseV5, promise6, promises);
-		return new AndroidDeferredObject<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>(p, scope).promise();
+		AndroidDeferredObject<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress> deferredObject = new AndroidDeferredObject<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>(p, scope);
+		deferredObject.setCallbackExceptionHandler(callbackExceptionHandler);
+		return ((AndroidDeferredObject<MultipleResultsN<V1, V2, V3, V4, V5>, OneReject<R>, MasterProgress>) deferredObject).promise();
 	}
 
 	@Override

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/CallbackExceptionHandler.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/CallbackExceptionHandler.java
@@ -21,7 +21,7 @@ package org.jdeferred;
  * @author Ray Tsang
  */
 public interface CallbackExceptionHandler {
-	public static enum CallbackType {
+	enum CallbackType {
 		DONE_CALLBACK,
 		FAIL_CALLBACK,
 		PROGRESS_CALLBACK,

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/DeferredManager.java
@@ -596,4 +596,8 @@ public interface DeferredManager {
 	 * @throws IllegalArgumentException if any item in iterable cannot be converted to a {@link Promise}
 	 */
 	Promise<AllValues, Throwable, MasterProgress> settle(Iterable<?> iterable);
+
+	void setCallbackExceptionHandler(CallbackExceptionHandler callbackExceptionHandler);
+
+	CallbackExceptionHandler getCallbackExceptionHandler();
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
@@ -338,4 +338,8 @@ public interface Promise<D, F, P> {
 	 * @throws InterruptedException
 	 */
 	void waitSafely(long timeout) throws InterruptedException;
+
+	Promise<D, F, P> setCallbackExceptionHandler(CallbackExceptionHandler callbackExceptionHandler);
+
+	CallbackExceptionHandler getCallbackExceptionHandler();
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractDeferredManager.java
@@ -15,6 +15,7 @@
  */
 package org.jdeferred.impl;
 
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.DeferredCallable;
 import org.jdeferred.DeferredFutureTask;
 import org.jdeferred.DeferredManager;
@@ -30,8 +31,6 @@ import org.jdeferred.multiple.MultipleResults5;
 import org.jdeferred.multiple.MultipleResultsN;
 import org.jdeferred.multiple.OneReject;
 import org.jdeferred.multiple.OneResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -73,7 +72,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 	protected static final String FUTURE_V4 = "futureV4";
 	protected static final String FUTURE_V5 = "futureV5";
 
-	final protected Logger log = LoggerFactory.getLogger(AbstractDeferredManager.class);
+	protected CallbackExceptionHandler callbackExceptionHandler;
 
 	protected abstract void submit(Runnable runnable);
 
@@ -91,7 +90,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 	public <F, V1, V2> Promise<MultipleResults2<V1, V2>, OneReject<F>, MasterProgress> when(Promise<V1, ?, ?> promiseV1, Promise<V2, ?, ?> promiseV2) {
 		assertNotNull(promiseV1, PROMISE_V1);
 		assertNotNull(promiseV2, PROMISE_V2);
-		return new MasterDeferredObject2(promiseV1, promiseV2);
+		return new MasterDeferredObject2(callbackExceptionHandler, promiseV1, promiseV2);
 	}
 
 	@Override
@@ -99,7 +98,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(promiseV1, PROMISE_V1);
 		assertNotNull(promiseV2, PROMISE_V2);
 		assertNotNull(promiseV3, PROMISE_V3);
-		return new MasterDeferredObject3(promiseV1, promiseV2, promiseV3);
+		return new MasterDeferredObject3(callbackExceptionHandler, promiseV1, promiseV2, promiseV3);
 	}
 
 	@Override
@@ -108,7 +107,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(promiseV2, PROMISE_V2);
 		assertNotNull(promiseV3, PROMISE_V3);
 		assertNotNull(promiseV4, PROMISE_V4);
-		return new MasterDeferredObject4(promiseV1, promiseV2, promiseV3, promiseV4);
+		return new MasterDeferredObject4(callbackExceptionHandler, promiseV1, promiseV2, promiseV3, promiseV4);
 	}
 
 	@Override
@@ -118,7 +117,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(promiseV3, PROMISE_V3);
 		assertNotNull(promiseV4, PROMISE_V4);
 		assertNotNull(promiseV5, PROMISE_V5);
-		return new MasterDeferredObject5(promiseV1, promiseV2, promiseV3, promiseV4, promiseV5);
+		return new MasterDeferredObject5(callbackExceptionHandler, promiseV1, promiseV2, promiseV3, promiseV4, promiseV5);
 	}
 
 	@Override
@@ -132,7 +131,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 
 		Promise[] promiseN = new Promise[promises.length - 5];
 		System.arraycopy(promises, 5, promiseN, 0, promiseN.length);
-		return new MasterDeferredObjectN(promiseV1, promiseV2, promiseV3, promiseV4, promiseV5, promise6, promiseN);
+		return new MasterDeferredObjectN(callbackExceptionHandler, promiseV1, promiseV2, promiseV3, promiseV4, promiseV5, promise6, promiseN);
 	}
 
 	@Override
@@ -159,7 +158,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			default:
 				Promise[] promiseN = new Promise[promises.length - 5];
 				System.arraycopy(promises, 5, promiseN, 0, promiseN.length);
-				return new MasterDeferredObjectN(promises[0], promises[1], promises[2], promises[3], promises[4], promises[5], promiseN);
+				return new MasterDeferredObjectN(callbackExceptionHandler, promises[0], promises[1], promises[2], promises[3], promises[4], promises[5], promiseN);
 		}
 	}
 
@@ -167,7 +166,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 	public <V1, V2> Promise<MultipleResults2<V1, V2>, OneReject<Throwable>, MasterProgress> when(Callable<V1> callableV1, Callable<V2> callableV2) {
 		assertNotNull(callableV1, CALLABLE_V1);
 		assertNotNull(callableV2, CALLABLE_V2);
-		return new MasterDeferredObject2(when(callableV1), when(callableV2));
+		return new MasterDeferredObject2(callbackExceptionHandler, when(callableV1), when(callableV2));
 	}
 
 	@Override
@@ -175,7 +174,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(callableV1, CALLABLE_V1);
 		assertNotNull(callableV2, CALLABLE_V2);
 		assertNotNull(callableV3, CALLABLE_V3);
-		return new MasterDeferredObject3(when(callableV1), when(callableV2), when(callableV3));
+		return new MasterDeferredObject3(callbackExceptionHandler, when(callableV1), when(callableV2), when(callableV3));
 	}
 
 	@Override
@@ -184,7 +183,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(callableV2, CALLABLE_V2);
 		assertNotNull(callableV3, CALLABLE_V3);
 		assertNotNull(callableV4, CALLABLE_V4);
-		return new MasterDeferredObject4(when(callableV1), when(callableV2), when(callableV3), when(callableV4));
+		return new MasterDeferredObject4(callbackExceptionHandler, when(callableV1), when(callableV2), when(callableV3), when(callableV4));
 	}
 
 	@Override
@@ -194,7 +193,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(callableV3, CALLABLE_V3);
 		assertNotNull(callableV4, CALLABLE_V4);
 		assertNotNull(callableV5, CALLABLE_V5);
-		return new MasterDeferredObject5(when(callableV1), when(callableV2), when(callableV3), when(callableV4), when(callableV5));
+		return new MasterDeferredObject5(callbackExceptionHandler, when(callableV1), when(callableV2), when(callableV3), when(callableV4), when(callableV5));
 	}
 
 	@Override
@@ -220,7 +219,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 				promiseN[i] = when(callables[i]);
 			}
 		}
-		return new MasterDeferredObjectN(promise1, promise2, promise3, promise4, promise5, when(callable6), promiseN);
+		return new MasterDeferredObjectN(callbackExceptionHandler, promise1, promise2, promise3, promise4, promise5, when(callable6), promiseN);
 	}
 
 	@Override
@@ -229,7 +228,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		DeferredRunnable<P2> runnableP2) {
 		assertNotNull(runnableP1, RUNNABLE_V1);
 		assertNotNull(runnableP2, RUNNABLE_V2);
-		return new MasterDeferredObject2(when(runnableP1), when(runnableP2));
+		return new MasterDeferredObject2(callbackExceptionHandler, when(runnableP1), when(runnableP2));
 	}
 
 	@Override
@@ -240,7 +239,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(runnableP1, RUNNABLE_V1);
 		assertNotNull(runnableP2, RUNNABLE_V2);
 		assertNotNull(runnableP3, RUNNABLE_V3);
-		return new MasterDeferredObject3(when(runnableP1), when(runnableP2), when(runnableP3));
+		return new MasterDeferredObject3(callbackExceptionHandler, when(runnableP1), when(runnableP2), when(runnableP3));
 	}
 
 	@Override
@@ -253,7 +252,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(runnableP2, RUNNABLE_V2);
 		assertNotNull(runnableP3, RUNNABLE_V3);
 		assertNotNull(runnableP4, RUNNABLE_V4);
-		return new MasterDeferredObject4(when(runnableP1), when(runnableP2), when(runnableP3), when(runnableP4));
+		return new MasterDeferredObject4(callbackExceptionHandler, when(runnableP1), when(runnableP2), when(runnableP3), when(runnableP4));
 	}
 
 	@Override
@@ -268,7 +267,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(runnableP3, RUNNABLE_V3);
 		assertNotNull(runnableP4, RUNNABLE_V4);
 		assertNotNull(runnableP5, RUNNABLE_V5);
-		return new MasterDeferredObject5(when(runnableP1), when(runnableP2), when(runnableP3), when(runnableP4), when(runnableP5));
+		return new MasterDeferredObject5(callbackExceptionHandler, when(runnableP1), when(runnableP2), when(runnableP3), when(runnableP4), when(runnableP5));
 	}
 
 	@Override
@@ -298,14 +297,14 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		for (int i = 0; i < runnables.length; i++) {
 			promiseN[i] = when(runnables[i]);
 		}
-		return new MasterDeferredObjectN(promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
+		return new MasterDeferredObjectN(callbackExceptionHandler, promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
 	}
 
 	@Override
 	public <V1, V2> Promise<MultipleResults2<V1, V2>, OneReject<Throwable>, MasterProgress> when(DeferredCallable<V1, ?> callableV1, DeferredCallable<V2, ?> callableV2) {
 		assertNotNull(callableV1, CALLABLE_V1);
 		assertNotNull(callableV2, CALLABLE_V2);
-		return new MasterDeferredObject2(when(callableV1), when(callableV2));
+		return new MasterDeferredObject2(callbackExceptionHandler, when(callableV1), when(callableV2));
 	}
 
 	@Override
@@ -313,7 +312,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(callableV1, CALLABLE_V1);
 		assertNotNull(callableV2, CALLABLE_V2);
 		assertNotNull(callableV3, CALLABLE_V3);
-		return new MasterDeferredObject3(when(callableV1), when(callableV2), when(callableV3));
+		return new MasterDeferredObject3(callbackExceptionHandler, when(callableV1), when(callableV2), when(callableV3));
 	}
 
 	@Override
@@ -322,7 +321,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(callableV2, CALLABLE_V2);
 		assertNotNull(callableV3, CALLABLE_V3);
 		assertNotNull(callableV4, CALLABLE_V4);
-		return new MasterDeferredObject4(when(callableV1), when(callableV2), when(callableV3), when(callableV4));
+		return new MasterDeferredObject4(callbackExceptionHandler, when(callableV1), when(callableV2), when(callableV3), when(callableV4));
 	}
 
 	@Override
@@ -332,7 +331,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(callableV3, CALLABLE_V3);
 		assertNotNull(callableV4, CALLABLE_V4);
 		assertNotNull(callableV5, CALLABLE_V5);
-		return new MasterDeferredObject5(when(callableV1), when(callableV2), when(callableV3), when(callableV4), when(callableV5));
+		return new MasterDeferredObject5(callbackExceptionHandler, when(callableV1), when(callableV2), when(callableV3), when(callableV4), when(callableV5));
 	}
 
 	@Override
@@ -355,14 +354,14 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		for (int i = 0; i < callables.length; i++) {
 			promiseN[i] = when(callables[i]);
 		}
-		return new MasterDeferredObjectN(promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
+		return new MasterDeferredObjectN(callbackExceptionHandler, promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
 	}
 
 	@Override
 	public <V1, V2> Promise<MultipleResults2<V1, V2>, OneReject<Throwable>, MasterProgress> when(DeferredFutureTask<V1, ?> taskV1, DeferredFutureTask<V2, ?> taskV2) {
 		assertNotNull(taskV1, TASK_V1);
 		assertNotNull(taskV2, TASK_V2);
-		return new MasterDeferredObject2(when(taskV1), when(taskV2));
+		return new MasterDeferredObject2(callbackExceptionHandler, when(taskV1), when(taskV2));
 	}
 
 	@Override
@@ -370,7 +369,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(taskV1, TASK_V1);
 		assertNotNull(taskV2, TASK_V2);
 		assertNotNull(taskV3, TASK_V3);
-		return new MasterDeferredObject3(when(taskV1), when(taskV2), when(taskV3));
+		return new MasterDeferredObject3(callbackExceptionHandler, when(taskV1), when(taskV2), when(taskV3));
 	}
 
 	@Override
@@ -379,7 +378,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(taskV2, TASK_V2);
 		assertNotNull(taskV3, TASK_V3);
 		assertNotNull(taskV4, TASK_V4);
-		return new MasterDeferredObject4(when(taskV1), when(taskV2), when(taskV3), when(taskV4));
+		return new MasterDeferredObject4(callbackExceptionHandler, when(taskV1), when(taskV2), when(taskV3), when(taskV4));
 	}
 
 	@Override
@@ -389,7 +388,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(taskV3, TASK_V3);
 		assertNotNull(taskV4, TASK_V4);
 		assertNotNull(taskV5, TASK_V5);
-		return new MasterDeferredObject5(when(taskV1), when(taskV2), when(taskV3), when(taskV4), when(taskV5));
+		return new MasterDeferredObject5(callbackExceptionHandler, when(taskV1), when(taskV2), when(taskV3), when(taskV4), when(taskV5));
 	}
 
 	@Override
@@ -412,14 +411,14 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		for (int i = 0; i < tasks.length; i++) {
 			promiseN[i] = when(tasks[i]);
 		}
-		return new MasterDeferredObjectN(promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
+		return new MasterDeferredObjectN(callbackExceptionHandler, promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
 	}
 
 	@Override
 	public <V1, V2> Promise<MultipleResults2<V1, V2>, OneReject<Throwable>, MasterProgress> when(Future<V1> futureV1, Future<V2> futureV2) {
 		assertNotNull(futureV1, FUTURE_V1);
 		assertNotNull(futureV2, FUTURE_V2);
-		return new MasterDeferredObject2(when(futureV1), when(futureV2));
+		return new MasterDeferredObject2(callbackExceptionHandler, when(futureV1), when(futureV2));
 	}
 
 	@Override
@@ -427,7 +426,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(futureV1, FUTURE_V1);
 		assertNotNull(futureV2, FUTURE_V2);
 		assertNotNull(futureV3, FUTURE_V3);
-		return new MasterDeferredObject3(when(futureV1), when(futureV2), when(futureV3));
+		return new MasterDeferredObject3(callbackExceptionHandler, when(futureV1), when(futureV2), when(futureV3));
 	}
 
 	@Override
@@ -436,7 +435,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(futureV2, FUTURE_V2);
 		assertNotNull(futureV3, FUTURE_V3);
 		assertNotNull(futureV4, FUTURE_V4);
-		return new MasterDeferredObject4(when(futureV1), when(futureV2), when(futureV3), when(futureV4));
+		return new MasterDeferredObject4(callbackExceptionHandler, when(futureV1), when(futureV2), when(futureV3), when(futureV4));
 	}
 
 	@Override
@@ -446,7 +445,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		assertNotNull(futureV3, FUTURE_V3);
 		assertNotNull(futureV4, FUTURE_V4);
 		assertNotNull(futureV5, FUTURE_V5);
-		return new MasterDeferredObject5(when(futureV1), when(futureV2), when(futureV3), when(futureV4), when(futureV5));
+		return new MasterDeferredObject5(callbackExceptionHandler, when(futureV1), when(futureV2), when(futureV3), when(futureV4), when(futureV5));
 	}
 
 	@Override
@@ -469,37 +468,46 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		for (int i = 0; i < futures.length; i++) {
 			promiseN[i] = when(futures[i]);
 		}
-		return new MasterDeferredObjectN(promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
+		return new MasterDeferredObjectN(callbackExceptionHandler, promise1, promise2, promise3, promise4, promise5, promise6, promiseN);
 	}
 
 	@Override
 	public <D, F, P> Promise<D, F, P> when(Promise<D, F, P> promise) {
 		assertNotNull(promise, "promise");
+		promise.setCallbackExceptionHandler(callbackExceptionHandler);
 		return promise;
 	}
 
 	@Override
 	public <P> Promise<Void, Throwable, P> when(DeferredRunnable<P> runnable) {
 		assertNotNull(runnable, "runnable");
-		return when(new DeferredFutureTask<Void, P>(runnable));
+		Promise<Void, Throwable, P> promise = when(new DeferredFutureTask<Void, P>(runnable));
+		promise.setCallbackExceptionHandler(callbackExceptionHandler);
+		return promise;
 	}
 
 	@Override
 	public <D, P> Promise<D, Throwable, P> when(DeferredCallable<D, P> callable) {
 		assertNotNull(callable, "callable");
-		return when(new DeferredFutureTask<D, P>(callable));
+		Promise<D, Throwable, P> promise = when(new DeferredFutureTask<D, P>(callable));
+		promise.setCallbackExceptionHandler(callbackExceptionHandler);
+		return promise;
 	}
 
 	@Override
 	public Promise<Void, Throwable, Void> when(Runnable runnable) {
 		assertNotNull(runnable, "runnable");
-		return when(new DeferredFutureTask<Void, Void>(runnable));
+		Promise<Void, Throwable, Void> promise = when(new DeferredFutureTask<Void, Void>(runnable));
+		promise.setCallbackExceptionHandler(callbackExceptionHandler);
+		return promise;
 	}
 
 	@Override
 	public <D> Promise<D, Throwable, Void> when(Callable<D> callable) {
 		assertNotNull(callable, "callable");
-		return when(new DeferredFutureTask<D, Void>(callable));
+		Promise<D, Throwable, Void> promise = when(new DeferredFutureTask<D, Void>(callable));
+		promise.setCallbackExceptionHandler(callbackExceptionHandler);
+		return promise;
 	}
 
 	@Override
@@ -510,13 +518,17 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			submit(task);
 		}
 
-		return task.promise();
+		Promise<D, Throwable, P> promise = task.promise();
+		promise.setCallbackExceptionHandler(callbackExceptionHandler);
+		return promise;
 	}
 
 	@Override
 	public <D> Promise<D, Throwable, Void> when(Future<D> future) {
 		// make sure the task is automatically started
-		return when(deferredCallableFor(future));
+		Promise<D, Throwable, Void> promise = when(deferredCallableFor(future));
+		promise.setCallbackExceptionHandler(callbackExceptionHandler);
+		return promise;
 	}
 
 	@Override
@@ -625,7 +637,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 		for (DeferredFutureTask<?, ?> task : tasks) {
 			submit(task);
 		}
-		return new SingleDeferredObject(tasks);
+		return new SingleDeferredObject(callbackExceptionHandler, tasks);
 	}
 
 	protected <D> DeferredCallable<D, Void> deferredCallableFor(final Future<D> future) {
@@ -663,7 +675,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			}
 		}
 
-		return new AllValuesDeferredObject(promises);
+		return new AllValuesDeferredObject(callbackExceptionHandler, promises);
 	}
 
 	@Override
@@ -680,7 +692,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			}
 		}
 
-		return new AllValuesDeferredObject(promises);
+		return new AllValuesDeferredObject(callbackExceptionHandler, promises);
 	}
 
 	@Override
@@ -697,7 +709,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			}
 		}
 
-		return new AllValuesDeferredObject(promises);
+		return new AllValuesDeferredObject(callbackExceptionHandler, promises);
 	}
 
 	@Override
@@ -714,7 +726,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			}
 		}
 
-		return new AllValuesDeferredObject(promises);
+		return new AllValuesDeferredObject(callbackExceptionHandler, promises);
 	}
 
 	@Override
@@ -731,7 +743,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			}
 		}
 
-		return new AllValuesDeferredObject(promises);
+		return new AllValuesDeferredObject(callbackExceptionHandler, promises);
 	}
 
 	@Override
@@ -748,7 +760,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			}
 		}
 
-		return new AllValuesDeferredObject(promises);
+		return new AllValuesDeferredObject(callbackExceptionHandler, promises);
 	}
 
 	@Override
@@ -763,7 +775,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			System.arraycopy(promises, 0, allPromises, 2, promises.length);
 		}
 
-		return new AllValuesDeferredObject(allPromises);
+		return new AllValuesDeferredObject(callbackExceptionHandler, allPromises);
 	}
 
 	@Deprecated
@@ -810,7 +822,7 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			promises.add(toPromise(item));
 		}
 
-		return new MasterDeferredObjectUntypedN(promises.toArray(new Promise[promises.size()])).promise();
+		return new MasterDeferredObjectUntypedN(callbackExceptionHandler, promises.toArray(new Promise[promises.size()])).promise();
 	}
 
 	@Override
@@ -879,7 +891,17 @@ public abstract class AbstractDeferredManager implements DeferredManager {
 			promises.add(toPromise(item));
 		}
 
-		return new AllValuesDeferredObject(promises.toArray(new Promise[promises.size()]));
+		return new AllValuesDeferredObject(callbackExceptionHandler, promises.toArray(new Promise[promises.size()]));
+	}
+
+	@Override
+	public CallbackExceptionHandler getCallbackExceptionHandler() {
+		return callbackExceptionHandler;
+	}
+
+	@Override
+	public void setCallbackExceptionHandler(CallbackExceptionHandler callbackExceptionHandler) {
+		this.callbackExceptionHandler = callbackExceptionHandler;
 	}
 
 	protected boolean canPromise(Object o) {

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractMasterDeferredObject.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractMasterDeferredObject.java
@@ -15,6 +15,7 @@
  */
 package org.jdeferred.impl;
 
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.DoneCallback;
 import org.jdeferred.FailCallback;
 import org.jdeferred.ProgressCallback;
@@ -36,12 +37,14 @@ class AbstractMasterDeferredObject extends DeferredObject<MultipleResults, OneRe
 	private final AtomicInteger doneCount = new AtomicInteger();
 	private final AtomicInteger failCount = new AtomicInteger();
 
-	AbstractMasterDeferredObject(MutableMultipleResults results) {
+	AbstractMasterDeferredObject(MutableMultipleResults results, CallbackExceptionHandler callbackExceptionHandler) {
 		this.results = results;
 		this.numberOfPromises = results.size();
+		setCallbackExceptionHandler(callbackExceptionHandler);
 	}
 
 	protected <D, F, P> void configurePromise(final int index, final Promise<D, F, P> promise) {
+		promise.setCallbackExceptionHandler(callbackExceptionHandler);
 		promise.fail(new FailCallback<F>() {
 			public void onFail(F result) {
 				synchronized (AbstractMasterDeferredObject.this) {

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AllValuesDeferredObject.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AllValuesDeferredObject.java
@@ -15,12 +15,13 @@
  */
 package org.jdeferred.impl;
 
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.DoneCallback;
 import org.jdeferred.FailCallback;
 import org.jdeferred.ProgressCallback;
 import org.jdeferred.Promise;
-import org.jdeferred.multiple.MasterProgress;
 import org.jdeferred.multiple.AllValues;
+import org.jdeferred.multiple.MasterProgress;
 import org.jdeferred.multiple.OneProgress;
 import org.jdeferred.multiple.OneReject;
 import org.jdeferred.multiple.OneResult;
@@ -36,7 +37,8 @@ class AllValuesDeferredObject extends DeferredObject<AllValues, Throwable, Maste
 	private final AtomicInteger doneCount = new AtomicInteger();
 	private final AtomicInteger failCount = new AtomicInteger();
 
-	AllValuesDeferredObject(Promise<?, ?, ?>[] promises) {
+	AllValuesDeferredObject(CallbackExceptionHandler callbackExceptionHandler, Promise<?, ?, ?>[] promises) {
+		setCallbackExceptionHandler(callbackExceptionHandler);
 		this.numberOfPromises = promises.length;
 		this.values = new DefaultMutableAllValues(promises.length);
 
@@ -46,6 +48,7 @@ class AllValuesDeferredObject extends DeferredObject<AllValues, Throwable, Maste
 	}
 
 	protected <D, F, P> void configurePromise(final int index, final Promise<D, F, P> promise) {
+		promise.setCallbackExceptionHandler(callbackExceptionHandler);
 		promise.fail(new FailCallback<F>() {
 			public void onFail(F result) {
 				synchronized (AllValuesDeferredObject.this) {

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DeferredPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DeferredPromise.java
@@ -16,6 +16,7 @@
 package org.jdeferred.impl;
 
 import org.jdeferred.AlwaysCallback;
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.Deferred;
 import org.jdeferred.DoneCallback;
 import org.jdeferred.DoneFilter;
@@ -31,13 +32,26 @@ import org.jdeferred.Promise;
 public class DeferredPromise<D, F, P> implements Promise<D, F, P> {
 	private final Promise<D, F, P> promise;
 	protected final Deferred<D, F, P> deferred;
+	private CallbackExceptionHandler callbackExceptionHandler;
 	
 	public DeferredPromise(Deferred<D, F, P> deferred) {
 		this.deferred = deferred;
 		this.promise = deferred.promise();
 	}
-	
-	public org.jdeferred.Promise.State state() {
+
+	@Override
+	public CallbackExceptionHandler getCallbackExceptionHandler() {
+		return callbackExceptionHandler;
+	}
+
+	@Override
+	public Promise<D, F, P> setCallbackExceptionHandler(CallbackExceptionHandler callbackExceptionHandler) {
+		this.callbackExceptionHandler = callbackExceptionHandler;
+		this.promise.setCallbackExceptionHandler(callbackExceptionHandler);
+		return this;
+	}
+
+	public Promise.State state() {
 		return promise.state();
 	}
 

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
@@ -16,6 +16,7 @@
 package org.jdeferred.impl;
 
 import org.jdeferred.AlwaysCallback;
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.DoneCallback;
 import org.jdeferred.DoneFilter;
 import org.jdeferred.DonePipe;
@@ -45,6 +46,17 @@ public abstract class DelegatingPromise<D, F, P> implements Promise<D, F, P> {
             throw new NullPointerException("Argument 'delegate' must not be null");
         }
         this.delegate = delegate;
+    }
+
+    @Override
+    public Promise<D, F, P> setCallbackExceptionHandler(CallbackExceptionHandler callbackExceptionHandler) {
+        getDelegate().setCallbackExceptionHandler(callbackExceptionHandler);
+        return this;
+    }
+
+    @Override
+    public CallbackExceptionHandler getCallbackExceptionHandler() {
+        return getDelegate().getCallbackExceptionHandler();
     }
 
     /**

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/FutureCallable.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/FutureCallable.java
@@ -38,5 +38,4 @@ public class FutureCallable<V> implements Callable<V> {
 			else throw e;
 		}
 	}
-
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/GlobalConfiguration.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/GlobalConfiguration.java
@@ -18,18 +18,28 @@ package org.jdeferred.impl;
 import org.jdeferred.CallbackExceptionHandler;
 
 public final class GlobalConfiguration {
+	private static final CallbackExceptionHandler NOOP_CALLBACK_EXCEPTION_HANDLER = new NoopCallbackExceptionHandler();
 	private static CallbackExceptionHandler globalCallbackExceptionHandler = new DefaultCallbackExceptionHandler();
 
-	private GlobalConfiguration() {};
+	private GlobalConfiguration() {
+	}
 
 	public static void setGlobalCallbackExceptionHandler(CallbackExceptionHandler callbackExceptionHandler) {
 		if (callbackExceptionHandler == null) {
-			throw new IllegalArgumentException("callbackExceptionHandler cannot be null");
+			globalCallbackExceptionHandler = NOOP_CALLBACK_EXCEPTION_HANDLER;
+		} else {
+			globalCallbackExceptionHandler = callbackExceptionHandler;
 		}
-		globalCallbackExceptionHandler = callbackExceptionHandler;
 	}
 
 	public static CallbackExceptionHandler getGlobalCallbackExceptionHandler() {
 		return globalCallbackExceptionHandler;
+	}
+
+	public static final class NoopCallbackExceptionHandler implements CallbackExceptionHandler {
+		@Override
+		public void handleException(CallbackType callbackType, Exception e) {
+			// empty
+		}
 	}
 }

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject2.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject2.java
@@ -15,6 +15,7 @@
  */
 package org.jdeferred.impl;
 
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.Promise;
 
 /***
@@ -22,9 +23,10 @@ import org.jdeferred.Promise;
  * @author Andres Almiray
  */
 class MasterDeferredObject2<V1, V2> extends AbstractMasterDeferredObject {
-	MasterDeferredObject2(Promise<V1, ?, ?> promiseV1,
+	MasterDeferredObject2(CallbackExceptionHandler callbackExceptionHandler,
+	                      Promise<V1, ?, ?> promiseV1,
 	                      Promise<V2, ?, ?> promiseV2) {
-		super(new MutableMultipleResults2<V1, V2>());
+		super(new MutableMultipleResults2<V1, V2>(), callbackExceptionHandler);
 		configurePromise(0, promiseV1);
 		configurePromise(1, promiseV2);
 	}

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject3.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject3.java
@@ -15,6 +15,7 @@
  */
 package org.jdeferred.impl;
 
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.Promise;
 
 /***
@@ -22,10 +23,11 @@ import org.jdeferred.Promise;
  * @author Andres Almiray
  */
 class MasterDeferredObject3<V1, V2, V3> extends AbstractMasterDeferredObject {
-	MasterDeferredObject3(Promise<V1, ?, ?> promiseV1,
+	MasterDeferredObject3(CallbackExceptionHandler callbackExceptionHandler,
+	                      Promise<V1, ?, ?> promiseV1,
 	                      Promise<V2, ?, ?> promiseV2,
 	                      Promise<V3, ?, ?> promiseV3) {
-		super(new MutableMultipleResults3<V1, V2, V3>());
+		super(new MutableMultipleResults3<V1, V2, V3>(), callbackExceptionHandler);
 		configurePromise(0, promiseV1);
 		configurePromise(1, promiseV2);
 		configurePromise(2, promiseV3);

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject4.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject4.java
@@ -15,6 +15,7 @@
  */
 package org.jdeferred.impl;
 
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.Promise;
 
 /***
@@ -22,11 +23,12 @@ import org.jdeferred.Promise;
  * @author Andres Almiray
  */
 class MasterDeferredObject4<V1, V2, V3, V4> extends AbstractMasterDeferredObject {
-	MasterDeferredObject4(Promise<V1, ?, ?> promiseV1,
+	MasterDeferredObject4(CallbackExceptionHandler callbackExceptionHandler,
+	                      Promise<V1, ?, ?> promiseV1,
 	                      Promise<V2, ?, ?> promiseV2,
 	                      Promise<V3, ?, ?> promiseV3,
 	                      Promise<V4, ?, ?> promiseV4) {
-		super(new MutableMultipleResults4<V1, V2, V3, V4>());
+		super(new MutableMultipleResults4<V1, V2, V3, V4>(), callbackExceptionHandler);
 		configurePromise(0, promiseV1);
 		configurePromise(1, promiseV2);
 		configurePromise(2, promiseV3);

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject5.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObject5.java
@@ -15,6 +15,7 @@
  */
 package org.jdeferred.impl;
 
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.Promise;
 
 /***
@@ -22,12 +23,13 @@ import org.jdeferred.Promise;
  * @author Andres Almiray
  */
 class MasterDeferredObject5<V1, V2, V3, V4, V5> extends AbstractMasterDeferredObject {
-	MasterDeferredObject5(Promise<V1, ?, ?> promiseV1,
+	MasterDeferredObject5(CallbackExceptionHandler callbackExceptionHandler,
+	                      Promise<V1, ?, ?> promiseV1,
 	                      Promise<V2, ?, ?> promiseV2,
 	                      Promise<V3, ?, ?> promiseV3,
 	                      Promise<V4, ?, ?> promiseV4,
 	                      Promise<V5, ?, ?> promiseV5) {
-		super(new MutableMultipleResults5<V1, V2, V3, V4, V5>());
+		super(new MutableMultipleResults5<V1, V2, V3, V4, V5>(), callbackExceptionHandler);
 		configurePromise(0, promiseV1);
 		configurePromise(1, promiseV2);
 		configurePromise(2, promiseV3);

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObjectN.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObjectN.java
@@ -15,6 +15,7 @@
  */
 package org.jdeferred.impl;
 
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.Promise;
 
 /***
@@ -22,14 +23,15 @@ import org.jdeferred.Promise;
  * @author Andres Almiray
  */
 class MasterDeferredObjectN<V1, V2, V3, V4, V5> extends AbstractMasterDeferredObject {
-	MasterDeferredObjectN(Promise<V1, ?, ?> promiseV1,
+	MasterDeferredObjectN(CallbackExceptionHandler callbackExceptionHandler,
+	                      Promise<V1, ?, ?> promiseV1,
 	                      Promise<V2, ?, ?> promiseV2,
 	                      Promise<V3, ?, ?> promiseV3,
 	                      Promise<V4, ?, ?> promiseV4,
 	                      Promise<V5, ?, ?> promiseV5,
 	                      Promise<?, ?, ?> promise6,
 	                      Promise<?, ?, ?>... promises) {
-		super(new MutableMultipleResultsN<V1, V2, V3, V4, V5>(6 + promises.length));
+		super(new MutableMultipleResultsN<V1, V2, V3, V4, V5>(6 + promises.length), callbackExceptionHandler);
 		configurePromise(0, promiseV1);
 		configurePromise(1, promiseV2);
 		configurePromise(2, promiseV3);

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObjectUntypedN.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/MasterDeferredObjectUntypedN.java
@@ -15,6 +15,7 @@
  */
 package org.jdeferred.impl;
 
+import org.jdeferred.CallbackExceptionHandler;
 import org.jdeferred.Promise;
 
 /***
@@ -22,8 +23,8 @@ import org.jdeferred.Promise;
  * @author Andres Almiray
  */
 class MasterDeferredObjectUntypedN extends AbstractMasterDeferredObject {
-	MasterDeferredObjectUntypedN(Promise<?, ?, ?>... promises) {
-		super(new MutableMultipleResultsUntypedN(promises.length));
+	MasterDeferredObjectUntypedN(CallbackExceptionHandler callbackExceptionHandler, Promise<?, ?, ?>... promises) {
+		super(new MutableMultipleResultsUntypedN(promises.length), callbackExceptionHandler);
 		for (int i = 0; i < promises.length; i++) {
 			configurePromise(i, promises[i]);
 		}


### PR DESCRIPTION
The result of a quick spike to figure out if it's possible to define `CallbackExceptionHandler` on both `DeferredManager` and `Promise` in order to have localized exception handling. The current rules are:
 - setting CEH on a `Promise`  (once submitted) takes precedence over the other CEH (as long as it's set before any callback resolves).
 - every `Promise` passes on its CEH to any `Promise` created by it, such as `FilteredPromise` and `PipedPromise`, in other words children promises inherit the CEH from their parent.
 - setting CEH on `DeferredManager` sets it on every `Promise` created by this DM. 

Precedence of invocation for CEH is thus set as: promise, dm, global.
Please have a look at `FailureTest` to see how this mechanism works.