### PR TITLE
improve generics of promise

### DIFF
--- a/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
+++ b/subprojects/jdeferred-android/src/main/java/org/jdeferred/android/AndroidDeferredObject.java
@@ -102,7 +102,7 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 		}
 	}
 
-	protected void triggerDone(DoneCallback<D> callback, D resolved) {
+	protected void triggerDone(DoneCallback<? super D> callback, D resolved) {
 		if (determineAndroidExecutionScope(callback) == AndroidExecutionScope.UI) {
 			executeInUiThread(MESSAGE_POST_DONE, callback, State.RESOLVED,
 					resolved, null, null);
@@ -111,7 +111,7 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 		}
 	};
 
-	protected void triggerFail(FailCallback<F> callback, F rejected) {
+	protected void triggerFail(FailCallback<? super F> callback, F rejected) {
 		if (determineAndroidExecutionScope(callback) == AndroidExecutionScope.UI) {
 			executeInUiThread(MESSAGE_POST_FAIL, callback, State.REJECTED,
 					null, rejected, null);
@@ -120,7 +120,7 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 		}
 	};
 
-	protected void triggerProgress(ProgressCallback<P> callback, P progress) {
+	protected void triggerProgress(ProgressCallback<? super P> callback, P progress) {
 		if (determineAndroidExecutionScope(callback) == AndroidExecutionScope.UI) {
 			executeInUiThread(MESSAGE_POST_PROGRESS, callback, State.PENDING,
 					null, null, progress);
@@ -129,7 +129,7 @@ public class AndroidDeferredObject<D, F, P> extends DeferredObject<D, F, P> {
 		}
 	};
 
-	protected void triggerAlways(AlwaysCallback<D, F> callback, State state,
+	protected void triggerAlways(AlwaysCallback<? super D, ? super F> callback, State state,
 			D resolve, F reject) {
 		if (determineAndroidExecutionScope(callback) == AndroidExecutionScope.UI) {
 			executeInUiThread(MESSAGE_POST_ALWAYS, callback, state, resolve,

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
@@ -137,7 +137,7 @@ public interface Promise<D, F, P> {
 	 * @param doneFilter the filter to execute when a result is available
 	 * @return a new promise for the filtered result
 	 */
-	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(DoneFilter<D, D_OUT> doneFilter);
+	<D_OUT> Promise<D_OUT, F, P> then(DoneFilter<D, D_OUT> doneFilter);
 
 	/**
 	 * Equivalent to {@code then(doneFilter, failFilter, null)}
@@ -147,7 +147,7 @@ public interface Promise<D, F, P> {
 	 * @param failFilter the filter to execute when a failure is available
 	 * @return a new promise for the filtered result and failure.
 	 */
-	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
+	<D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(
 			DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter);
 
 	/**
@@ -206,8 +206,7 @@ public interface Promise<D, F, P> {
 	 * @param donePipe the pipe to invoke when a result is available
 	 * @return a new promise for the piped result.
 	 */
-	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
-			DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe);
+	<D_OUT> Promise<D_OUT, F, P> then(DonePipe<D, D_OUT, F, P> donePipe);
 
 	/**
 	 * Equivalent to {@code then(DonePipe, FailPipe, null)}
@@ -217,8 +216,8 @@ public interface Promise<D, F, P> {
 	 * @param failPipe the pipe to invoke when a failure is available
 	 * @return a new promise for the piped result and failure.
 	 */
-	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
-			DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe, FailPipe<F, D_OUT, F_OUT, P_OUT> failPipe);
+	<D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(
+			DonePipe<D, D_OUT, F_OUT, P> donePipe, FailPipe<F, D_OUT, F_OUT, P> failPipe);
 
 	/**
 	 * This method will register pipes such that when a Deferred object is either

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/Promise.java
@@ -108,7 +108,7 @@ public interface Promise<D, F, P> {
 	 * @param doneCallback see {@link #done(DoneCallback)}
 	 * @return {@code this} for chaining more calls
 	 */
-	Promise<D, F, P> then(DoneCallback<D> doneCallback);
+	Promise<D, F, P> then(DoneCallback<? super D> doneCallback);
 
 	/**
 	 * Equivalent to {@link #done(DoneCallback)}.{@link #fail(FailCallback)}
@@ -117,7 +117,7 @@ public interface Promise<D, F, P> {
 	 * @param failCallback see {@link #fail(FailCallback)}
 	 * @return {@code this} for chaining more calls
 	 */
-	Promise<D, F, P> then(DoneCallback<D> doneCallback, FailCallback<F> failCallback);
+	Promise<D, F, P> then(DoneCallback<? super D> doneCallback, FailCallback<? super F> failCallback);
 
 	/**
 	 * Equivalent to {@link #done(DoneCallback)}.{@link #fail(FailCallback)}.{@link #progress(ProgressCallback)}
@@ -127,8 +127,8 @@ public interface Promise<D, F, P> {
 	 * @param progressCallback see {@link #progress(ProgressCallback)}
 	 * @return {@code this} for chaining more calls
 	 */
-	Promise<D, F, P> then(DoneCallback<D> doneCallback,
-			FailCallback<F> failCallback, ProgressCallback<P> progressCallback);
+	Promise<D, F, P> then(DoneCallback<? super D> doneCallback,
+			FailCallback<? super F> failCallback, ProgressCallback<? super P> progressCallback);
 
 	/**
 	 * Equivalent to {@code then(doneFilter, null, null)}
@@ -137,7 +137,7 @@ public interface Promise<D, F, P> {
 	 * @param doneFilter the filter to execute when a result is available
 	 * @return a new promise for the filtered result
 	 */
-	<D_OUT> Promise<D_OUT, F, P> then(DoneFilter<D, D_OUT> doneFilter);
+	<D_OUT> Promise<D_OUT, F, P> then(DoneFilter<? super D, ? extends D_OUT> doneFilter);
 
 	/**
 	 * Equivalent to {@code then(doneFilter, failFilter, null)}
@@ -148,7 +148,8 @@ public interface Promise<D, F, P> {
 	 * @return a new promise for the filtered result and failure.
 	 */
 	<D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(
-			DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter);
+			DoneFilter<? super D, ? extends D_OUT> doneFilter,
+			FailFilter<? super F, ? extends F_OUT> failFilter);
 
 	/**
 	 * This method will register filters such that when a Deferred object is either
@@ -196,8 +197,9 @@ public interface Promise<D, F, P> {
 	 * @return a new promise for the filtered result, failure and progress.
 	 */
 	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
-			DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter,
-			ProgressFilter<P, P_OUT> progressFilter);
+			DoneFilter<? super D, ? extends D_OUT> doneFilter,
+			FailFilter<? super F, ? extends F_OUT> failFilter,
+			ProgressFilter<? super P, ? extends P_OUT> progressFilter);
 
 	/**
 	 * Equivalent to {#code then(DonePipe, null, null)}
@@ -206,7 +208,7 @@ public interface Promise<D, F, P> {
 	 * @param donePipe the pipe to invoke when a result is available
 	 * @return a new promise for the piped result.
 	 */
-	<D_OUT> Promise<D_OUT, F, P> then(DonePipe<D, D_OUT, F, P> donePipe);
+	<D_OUT> Promise<D_OUT, F, P> then(DonePipe<? super D, ? extends D_OUT, ? extends F, ? extends P> donePipe);
 
 	/**
 	 * Equivalent to {@code then(DonePipe, FailPipe, null)}
@@ -217,7 +219,8 @@ public interface Promise<D, F, P> {
 	 * @return a new promise for the piped result and failure.
 	 */
 	<D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(
-			DonePipe<D, D_OUT, F_OUT, P> donePipe, FailPipe<F, D_OUT, F_OUT, P> failPipe);
+			DonePipe<? super D, ? extends D_OUT, ? extends F_OUT, ? extends P> donePipe,
+			FailPipe<? super F, ? extends D_OUT, ? extends F_OUT, ? extends P> failPipe);
 
 	/**
 	 * This method will register pipes such that when a Deferred object is either
@@ -263,8 +266,9 @@ public interface Promise<D, F, P> {
 	 * @return a new promise for the piped result, failure and progress.
 	 */
 	<D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
-			DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe, FailPipe<F, D_OUT, F_OUT, P_OUT> failPipe,
-			ProgressPipe<P, D_OUT, F_OUT, P_OUT> progressPipe);
+			DonePipe<? super D, ? extends D_OUT, ? extends F_OUT, ? extends P_OUT> donePipe,
+			FailPipe<? super F, ? extends D_OUT, ? extends F_OUT, ? extends P_OUT> failPipe,
+			ProgressPipe<? super P, ? extends D_OUT, ? extends F_OUT, ? extends P_OUT> progressPipe);
 
 	/**
 	 * This method will register a pipe such that when a Deferred object is either
@@ -301,7 +305,8 @@ public interface Promise<D, F, P> {
 	 * @param alwaysPipe the pipe to invoke when a result or failure is available.
 	 * @return a new promise for the piped result or failure.
 	 */
-	<D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> always(AlwaysPipe<D, F, D_OUT, F_OUT, P> alwaysPipe);
+	<D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> always(
+			AlwaysPipe<? super D, ? super F, ? extends D_OUT, ? extends F_OUT, ? extends P> alwaysPipe);
 
 	/**
 	 * This method will register {@link DoneCallback} so that when a Deferred object
@@ -325,7 +330,7 @@ public interface Promise<D, F, P> {
 	 * @param callback the callback to be triggered
 	 * @return {@code this} for chaining more calls
 	 */
-	Promise<D, F, P> done(DoneCallback<D> callback);
+	Promise<D, F, P> done(DoneCallback<? super D> callback);
 
 	/**
 	 * This method will register {@link FailCallback} so that when a Deferred object
@@ -349,7 +354,7 @@ public interface Promise<D, F, P> {
 	 * @param callback the callback to be triggered
 	 * @return {@code this} for chaining more calls
 	 */
-	Promise<D, F, P> fail(FailCallback<F> callback);
+	Promise<D, F, P> fail(FailCallback<? super F> callback);
 
 	/**
 	 * This method will register {@link AlwaysCallback} so that when a Deferred object is either
@@ -383,7 +388,7 @@ public interface Promise<D, F, P> {
 	 * @param callback the callback to be triggered
 	 * @return {@code this} for chaining more calls
 	 */
-	Promise<D, F, P> always(AlwaysCallback<D, F> callback);
+	Promise<D, F, P> always(AlwaysCallback<? super D, ? super F> callback);
 
 	/**
 	 * This method will register {@link ProgressCallback} so that when a Deferred object
@@ -406,7 +411,7 @@ public interface Promise<D, F, P> {
 	 * @param callback the callback to be triggered
 	 * @return {@code this} for chaining more calls
 	 */
-	Promise<D, F, P> progress(ProgressCallback<P> callback);
+	Promise<D, F, P> progress(ProgressCallback<? super P> callback);
 
 	/**
 	 * This method will wait as long as the State is Pending.  This method will return fast

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/AbstractPromise.java
@@ -185,15 +185,15 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	}
 
 	@Override
-	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
+	public <D_OUT> Promise<D_OUT, F, P> then(
 			DoneFilter<D, D_OUT> doneFilter) {
-		return new FilteredPromise<D, F, P, D_OUT, F_OUT, P_OUT>(this, doneFilter, null, null);
+		return new FilteredPromise<D, F, P, D_OUT, F, P>(this, doneFilter, null, null);
 	}
 
 	@Override
-	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
+	public <D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(
 			DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter) {
-		return new FilteredPromise<D, F, P, D_OUT, F_OUT, P_OUT>(this, doneFilter, failFilter, null);
+		return new FilteredPromise<D, F, P, D_OUT, F_OUT, P>(this, doneFilter, failFilter, null);
 	}
 
 	@Override
@@ -204,16 +204,16 @@ public abstract class AbstractPromise<D, F, P> implements Promise<D, F, P> {
 	}
 
 	@Override
-	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
-			DonePipe<D, D_OUT, F_OUT, P_OUT> doneFilter) {
-		return new PipedPromise<D, F, P, D_OUT, F_OUT, P_OUT>(this, doneFilter, null, null);
+	public <D_OUT> Promise<D_OUT, F, P> then(
+			DonePipe<D, D_OUT, F, P> doneFilter) {
+		return new PipedPromise<D, F, P, D_OUT, F, P>(this, doneFilter, null, null);
 	}
 
 	@Override
-	public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(
-			DonePipe<D, D_OUT, F_OUT, P_OUT> doneFilter,
-			FailPipe<F, D_OUT, F_OUT, P_OUT> failFilter) {
-		return new PipedPromise<D, F, P, D_OUT, F_OUT, P_OUT>(this, doneFilter, failFilter, null);
+	public <D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(
+			DonePipe<D, D_OUT, F_OUT, P> doneFilter,
+			FailPipe<F, D_OUT, F_OUT, P> failFilter) {
+		return new PipedPromise<D, F, P, D_OUT, F_OUT, P>(this, doneFilter, failFilter, null);
 	}
 
 	@Override

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
@@ -93,12 +93,12 @@ public abstract class DelegatingPromise<D, F, P> implements Promise<D, F, P> {
     }
 
     @Override
-    public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(DoneFilter<D, D_OUT> doneFilter) {
+    public <D_OUT> Promise<D_OUT, F, P> then(DoneFilter<D, D_OUT> doneFilter) {
         return getDelegate().then(doneFilter);
     }
 
     @Override
-    public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter) {
+    public <D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter) {
         return getDelegate().then(doneFilter, failFilter);
     }
 
@@ -108,12 +108,12 @@ public abstract class DelegatingPromise<D, F, P> implements Promise<D, F, P> {
     }
 
     @Override
-    public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe) {
+    public <D_OUT> Promise<D_OUT, F, P> then(DonePipe<D, D_OUT, F, P> donePipe) {
         return getDelegate().then(donePipe);
     }
 
     @Override
-    public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe, FailPipe<F, D_OUT, F_OUT, P_OUT> failPipe) {
+    public <D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(DonePipe<D, D_OUT, F_OUT, P> donePipe, FailPipe<F, D_OUT, F_OUT, P> failPipe) {
         return getDelegate().then(donePipe, failPipe);
     }
 

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/DelegatingPromise.java
@@ -78,72 +78,80 @@ public abstract class DelegatingPromise<D, F, P> implements Promise<D, F, P> {
     }
 
     @Override
-    public Promise<D, F, P> then(DoneCallback<D> doneCallback) {
+    public Promise<D, F, P> then(DoneCallback<? super D> doneCallback) {
         return getDelegate().then(doneCallback);
     }
 
     @Override
-    public Promise<D, F, P> then(DoneCallback<D> doneCallback, FailCallback<F> failCallback) {
+    public Promise<D, F, P> then(DoneCallback<? super D> doneCallback, FailCallback<? super F> failCallback) {
         return getDelegate().then(doneCallback, failCallback);
     }
 
     @Override
-    public Promise<D, F, P> then(DoneCallback<D> doneCallback, FailCallback<F> failCallback, ProgressCallback<P> progressCallback) {
+    public Promise<D, F, P> then(DoneCallback<? super D> doneCallback,
+                                 FailCallback<? super F> failCallback,
+                                 ProgressCallback<? super P> progressCallback) {
         return getDelegate().then(doneCallback, failCallback, progressCallback);
     }
 
     @Override
-    public <D_OUT> Promise<D_OUT, F, P> then(DoneFilter<D, D_OUT> doneFilter) {
+    public <D_OUT> Promise<D_OUT, F, P> then(DoneFilter<? super D, ? extends D_OUT> doneFilter) {
         return getDelegate().then(doneFilter);
     }
 
     @Override
-    public <D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter) {
+    public <D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(DoneFilter<? super D, ? extends D_OUT> doneFilter,
+                                                        FailFilter<? super F, ? extends F_OUT> failFilter) {
         return getDelegate().then(doneFilter, failFilter);
     }
 
     @Override
-    public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(DoneFilter<D, D_OUT> doneFilter, FailFilter<F, F_OUT> failFilter, ProgressFilter<P, P_OUT> progressFilter) {
+    public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(DoneFilter<? super D, ? extends D_OUT> doneFilter,
+                                                                   FailFilter<? super F,? extends  F_OUT> failFilter,
+                                                                   ProgressFilter<? super P, ? extends P_OUT> progressFilter) {
         return getDelegate().then(doneFilter, failFilter, progressFilter);
     }
 
     @Override
-    public <D_OUT> Promise<D_OUT, F, P> then(DonePipe<D, D_OUT, F, P> donePipe) {
+    public <D_OUT> Promise<D_OUT, F, P> then(DonePipe<? super D, ? extends D_OUT, ? extends F, ? extends P> donePipe) {
         return getDelegate().then(donePipe);
     }
 
     @Override
-    public <D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(DonePipe<D, D_OUT, F_OUT, P> donePipe, FailPipe<F, D_OUT, F_OUT, P> failPipe) {
+    public <D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> then(DonePipe<? super D, ? extends D_OUT, ? extends F_OUT, ? extends P> donePipe,
+                                                        FailPipe<? super F, ? extends D_OUT, ? extends F_OUT, ? extends P> failPipe) {
         return getDelegate().then(donePipe, failPipe);
     }
 
     @Override
-    public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(DonePipe<D, D_OUT, F_OUT, P_OUT> donePipe, FailPipe<F, D_OUT, F_OUT, P_OUT> failPipe, ProgressPipe<P, D_OUT, F_OUT, P_OUT> progressPipe) {
+    public <D_OUT, F_OUT, P_OUT> Promise<D_OUT, F_OUT, P_OUT> then(DonePipe<? super D, ? extends D_OUT, ? extends F_OUT, ? extends P_OUT> donePipe,
+                                                                   FailPipe<? super F, ? extends D_OUT, ? extends F_OUT, ? extends P_OUT> failPipe,
+                                                                   ProgressPipe<? super P, ? extends D_OUT, ? extends F_OUT, ? extends P_OUT> progressPipe) {
         return getDelegate().then(donePipe, failPipe, progressPipe);
     }
 
     @Override
-    public <D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> always(AlwaysPipe<D, F, D_OUT, F_OUT, P> alwaysPipe) {
+    public <D_OUT, F_OUT> Promise<D_OUT, F_OUT, P> always(AlwaysPipe<? super D, ? super F, ? extends D_OUT, ? extends F_OUT, ? extends P> alwaysPipe) {
         return getDelegate().always(alwaysPipe);
     }
 
     @Override
-    public Promise<D, F, P> done(DoneCallback<D> callback) {
+    public Promise<D, F, P> done(DoneCallback<? super D> callback) {
         return getDelegate().done(callback);
     }
 
     @Override
-    public Promise<D, F, P> fail(FailCallback<F> callback) {
+    public Promise<D, F, P> fail(FailCallback<? super F> callback) {
         return getDelegate().fail(callback);
     }
 
     @Override
-    public Promise<D, F, P> always(AlwaysCallback<D, F> callback) {
+    public Promise<D, F, P> always(AlwaysCallback<? super D, ? super F> callback) {
         return getDelegate().always(callback);
     }
 
     @Override
-    public Promise<D, F, P> progress(ProgressCallback<P> callback) {
+    public Promise<D, F, P> progress(ProgressCallback<? super P> callback) {
         return getDelegate().progress(callback);
     }
 

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/FilteredPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/FilteredPromise.java
@@ -33,7 +33,10 @@ public class FilteredPromise<D, F, P, D_OUT, F_OUT, P_OUT> extends DeferredObjec
 	private final FailFilter<F, F_OUT> failFilter;
 	private final ProgressFilter<P, P_OUT> progressFilter;
 	
-	public FilteredPromise(final Promise<D, F, P> promise, final DoneFilter<D, D_OUT> doneFilter, final FailFilter<F, F_OUT> failFilter, final ProgressFilter<P, P_OUT> progressFilter) {
+	public FilteredPromise(final Promise<D, F, P> promise,
+						   final DoneFilter<? super D, ? extends D_OUT> doneFilter,
+						   final FailFilter<? super F, ? extends F_OUT> failFilter,
+						   final ProgressFilter<? super P, ? extends P_OUT> progressFilter) {
 		this.doneFilter = doneFilter == null ? NO_OP_DONE_FILTER : doneFilter;
 		this.failFilter = failFilter == null ? NO_OP_FAIL_FILTER : failFilter;
 		this.progressFilter = progressFilter == null ? NO_OP_PROGRESS_FILTER : progressFilter;

--- a/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/PipedPromise.java
+++ b/subprojects/jdeferred-core/src/main/java/org/jdeferred/impl/PipedPromise.java
@@ -27,7 +27,10 @@ import org.jdeferred.ProgressPipe;
 import org.jdeferred.Promise;
 
 public class PipedPromise<D, F, P, D_OUT, F_OUT, P_OUT> extends DeferredObject<D_OUT, F_OUT, P_OUT> implements Promise<D_OUT, F_OUT, P_OUT>{
-	public PipedPromise(final Promise<D, F, P> promise, final DonePipe<D, D_OUT, F_OUT, P_OUT> doneFilter, final FailPipe<F, D_OUT, F_OUT, P_OUT> failFilter, final ProgressPipe<P, D_OUT, F_OUT, P_OUT> progressFilter) {
+	public PipedPromise(final Promise<D, F, P> promise,
+						final DonePipe<? super D, ? extends D_OUT, ? extends F_OUT, ? extends P_OUT> doneFilter,
+						final FailPipe<? super F, ? extends D_OUT, ? extends F_OUT, ? extends P_OUT> failFilter,
+						final ProgressPipe<? super P, ? extends D_OUT, ? extends F_OUT, ? extends P_OUT> progressFilter) {
 		promise.done(new DoneCallback<D>() {
 			@SuppressWarnings("unchecked")
 			@Override
@@ -53,7 +56,8 @@ public class PipedPromise<D, F, P, D_OUT, F_OUT, P_OUT> extends DeferredObject<D
 		});
 	}
 	
-	public PipedPromise(final Promise<D, F, P_OUT> promise, final AlwaysPipe<D, F, D_OUT, F_OUT, P_OUT> alwaysFilter) {
+	public PipedPromise(final Promise<D, F, P_OUT> promise,
+						final AlwaysPipe<? super D, ? super F, ? extends D_OUT, ? extends F_OUT, ? extends P_OUT> alwaysFilter) {
 		promise.always(new AlwaysCallback<D, F>() {
 			@SuppressWarnings("unchecked")
 			@Override
@@ -68,7 +72,8 @@ public class PipedPromise<D, F, P, D_OUT, F_OUT, P_OUT> extends DeferredObject<D
 		});
 	}
 
-	protected Promise<D_OUT, F_OUT, P_OUT> pipe(Promise<D_OUT, F_OUT, P_OUT> promise) {
+	protected Promise<? extends D_OUT, ? extends F_OUT, ? extends P_OUT> pipe(
+			Promise<? extends D_OUT, ? extends F_OUT, ? extends P_OUT> promise) {
 		promise.done(new DoneCallback<D_OUT>() {
 			@Override
 			public void onDone(D_OUT result) {

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/FilteredPromiseTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/FilteredPromiseTest.java
@@ -56,7 +56,7 @@ public class FilteredPromiseTest extends AbstractDeferredTest {
 				return "DONE2";
 			}
 		})
-		.<String, Throwable, Void>then(null, new FilteredPromise.NoOpFailFilter<Throwable>())
+		.then((DoneFilter<String, String>) null, new FilteredPromise.NoOpFailFilter<Throwable>())
 		.done(new DoneCallback<String>() {
 			@Override
 			public void onDone(String result) {

--- a/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/PipedPromiseTest.java
+++ b/subprojects/jdeferred-core/src/test/java/org/jdeferred/impl/PipedPromiseTest.java
@@ -37,11 +37,11 @@ public class PipedPromiseTest extends AbstractDeferredTest {
 			}
 		};
 		
-		deferredManager.when(task).then(new DonePipe<Integer, Integer, Void, Void>() {
+		deferredManager.when(task).then(new DonePipe<Integer, Integer, Throwable, Void>() {
 			@Override
-			public Promise<Integer, Void, Void> pipeDone(Integer result) {
+			public Promise<Integer, Throwable, Void> pipeDone(Integer result) {
 				preRewireValue.set(result);
-				return new DeferredObject<Integer, Void, Void>().resolve(1000);
+				return new DeferredObject<Integer, Throwable, Void>().resolve(1000);
 			}
 		}).done(new DoneCallback<Integer>() {
 			@Override
@@ -185,14 +185,14 @@ public class PipedPromiseTest extends AbstractDeferredTest {
 			public Integer call() {
 				return 10;
 			}
-		}).then(new DonePipe<Integer, Integer, String, Void>() {
+		}).then(new DonePipe<Integer, Integer, Throwable, Void>() {
 			@Override
-			public Promise<Integer, String, Void> pipeDone(Integer result) {
+			public Promise<Integer, Throwable, Void> pipeDone(Integer result) {
 				preRewireValue.set(result);
 				if (result < 100) {
-					return new DeferredObject<Integer, String, Void>().reject("less than 100");
+					return new DeferredObject<Integer, Throwable, Void>().reject(new Exception("less than 100"));
 				} else {
-					return new DeferredObject<Integer, String, Void>().resolve(result);
+					return new DeferredObject<Integer, Throwable, Void>().resolve(result);
 				}
 			}
 		}).done(new DoneCallback<Integer>() {
@@ -200,10 +200,10 @@ public class PipedPromiseTest extends AbstractDeferredTest {
 			public void onDone(Integer result) {
 				postRewireValue.set(result);
 			}
-		}).fail(new FailCallback<String>() {
+		}).fail(new FailCallback<Throwable>() {
 			@Override
-			public void onFail(String result) {
-				failed.set(result);
+			public void onFail(Throwable result) {
+				failed.set(result.getMessage());
 			}
 		});
 		


### PR DESCRIPTION
resolves #154 

Note: **This is a breaking API change**
Never the less I think this will improve the experience of using jdeferred as the typing becomes more strict and therefore reduces possible runtime exceptions (such as ClassCastException)

On the same time by using "? super" and "? extends" the typing becomes relaxed as we now can do the following

    Promise<Integer, Throwable, Void> integerPromise = createIntegerPromise();
    Promise<Float, Throwable, Void> floatPromise = createFloatPromise();
    integerPromise.then(Helper::numberLogger)
    floatPromise.then(Helper::numberLogger)

where 

    public class Helper {
        public void numberLogger(Number n) {
            /* log number */
        }
    }

The Java Stream API also uses "? super" and "? extends" to allow maximal flexibility

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jdeferred/jdeferred/158)
<!-- Reviewable:end -->
